### PR TITLE
fix(worker): Use sync Redis Pub/Sub instead of async EventBus (Issue #7)

### DIFF
--- a/cine_mate/infra/worker.py
+++ b/cine_mate/infra/worker.py
@@ -4,10 +4,14 @@ RQ Worker - Executes Async Jobs
 Worker process that pulls jobs from the queue and executes them.
 For video generation, this calls upstream APIs (Kling, Runway, etc.).
 
+IMPORTANT (Issue #7 Fix):
+    Worker uses SYNC Redis Pub/Sub to publish events.
+    RQ requires sync functions, so we bypass async EventBus.
+
 Usage:
     # Start worker process
     $ python -m cine_mate.infra.worker
-    
+
     # Or with rq CLI
     $ rq worker cine_mate.infra.worker.execute_job
 """
@@ -15,24 +19,48 @@ Usage:
 import json
 import traceback
 from typing import Dict, Any
+from datetime import datetime
 
 import redis
 from rq import get_current_job
 
 from cine_mate.infra.schemas import JobStatus
-from cine_mate.infra.event_bus import EventBus, publish_node_completed, publish_node_failed
 
 
-# Global event bus instance
-_event_bus = None
+# Redis Pub/Sub channel names (match EventBus pattern)
+CHANNEL_NODE_COMPLETED = "cinemate:node_completed"
+CHANNEL_NODE_FAILED = "cinemate:node_failed"
 
 
-def get_event_bus(redis_url: str = "redis://localhost:6379") -> EventBus:
-    """Get or create global EventBus instance"""
-    global _event_bus
-    if _event_bus is None:
-        _event_bus = EventBus(redis_url)
-    return _event_bus
+def _publish_event_sync(
+    redis_conn: redis.Redis,
+    channel: str,
+    event_type: str,
+    run_id: str,
+    node_id: str,
+    payload: Dict[str, Any]
+):
+    """
+    Publish event via Redis Pub/Sub (SYNC version for Worker).
+
+    Issue #7 Fix: Bypass async EventBus, use sync Redis directly.
+
+    Args:
+        redis_conn: Redis connection (from RQ)
+        channel: Pub/Sub channel name
+        event_type: Event type string
+        run_id: Pipeline run ID
+        node_id: DAG node ID
+        payload: Event payload dict
+    """
+    message = {
+        "event_type": event_type,
+        "run_id": run_id,
+        "node_id": node_id,
+        "timestamp": datetime.utcnow().isoformat(),
+        "payload": payload
+    }
+    redis_conn.publish(channel, json.dumps(message))
 
 
 def execute_job(job_id: str):
@@ -76,24 +104,26 @@ def execute_job(job_id: str):
                 "result": json.dumps(result),
             }
         )
-        
-        # Publish node_completed event (会议决议：Event-Driven)
-        event_bus = get_event_bus()
-        import asyncio
-        asyncio.run(publish_node_completed(
-            event_bus=event_bus,
+
+        # Publish node_completed event (Issue #7 Fix: Use sync Redis Pub/Sub)
+        _publish_event_sync(
+            redis_conn=redis_conn,
+            channel=CHANNEL_NODE_COMPLETED,
+            event_type="node_completed",
             run_id=run_id,
             node_id=node_id,
-            artifact_hash=result.get("artifact_hash", ""),
-            output_url=result.get("output_url", ""),
-            cost=result.get("cost", 0.0)
-        ))
-        
+            payload={
+                "artifact_hash": result.get("artifact_hash", ""),
+                "output_url": result.get("output_url", ""),
+                "cost": result.get("cost", 0.0)
+            }
+        )
+
         print(f"[Worker] Job {job_id} completed successfully")
         
     except Exception as e:
         print(f"[Worker] Job {job_id} failed: {e}")
-        
+
         # Update job status in Redis
         tb = traceback.format_exc()
         redis_conn.hset(
@@ -104,22 +134,25 @@ def execute_job(job_id: str):
                 "error_traceback": tb,
             }
         )
-        
-        # Publish node_failed event
+
+        # Publish node_failed event (Issue #7 Fix: Use sync Redis Pub/Sub)
         try:
             job_data = redis_conn.hgetall(job_key)
-            event_bus = get_event_bus()
-            asyncio.run(publish_node_failed(
-                event_bus=event_bus,
+            _publish_event_sync(
+                redis_conn=redis_conn,
+                channel=CHANNEL_NODE_FAILED,
+                event_type="node_failed",
                 run_id=job_data.get("run_id"),
                 node_id=job_data.get("node_id"),
-                error_code="EXECUTION_ERROR",
-                error_msg=str(e),
-                retry_count=0
-            ))
+                payload={
+                    "error_code": "EXECUTION_ERROR",
+                    "error_msg": str(e),
+                    "retry_count": 0
+                }
+            )
         except Exception as event_error:
             print(f"[Worker] Failed to publish error event: {event_error}")
-        
+
         # Re-raise to let RQ handle retry logic
         raise
 

--- a/tests/unit/infra/test_worker.py
+++ b/tests/unit/infra/test_worker.py
@@ -1,0 +1,192 @@
+"""
+Tests for Worker (Issue #7 Fix)
+
+Verify that Worker can publish events via sync Redis Pub/Sub.
+"""
+
+import json
+import pytest
+from datetime import datetime
+from unittest.mock import Mock, MagicMock, patch
+
+from cine_mate.infra.worker import (
+    _publish_event_sync,
+    CHANNEL_NODE_COMPLETED,
+    CHANNEL_NODE_FAILED,
+    execute_job,
+    _execute_by_type,
+)
+
+
+class TestPublishEventSync:
+    """Test the sync event publishing function (Issue #7 Fix)."""
+
+    def test_publish_node_completed(self):
+        """Test publishing node_completed event via sync Redis."""
+        mock_redis = Mock()
+        mock_redis.publish = Mock()
+
+        _publish_event_sync(
+            redis_conn=mock_redis,
+            channel=CHANNEL_NODE_COMPLETED,
+            event_type="node_completed",
+            run_id="run_001",
+            node_id="node_A",
+            payload={
+                "artifact_hash": "sha256_abc123",
+                "output_url": "https://example.com/output.mp4",
+                "cost": 1.5
+            }
+        )
+
+        # Verify publish was called
+        assert mock_redis.publish.called
+        call_args = mock_redis.publish.call_args
+        assert call_args[0][0] == CHANNEL_NODE_COMPLETED
+
+        # Verify message structure
+        message = json.loads(call_args[0][1])
+        assert message["event_type"] == "node_completed"
+        assert message["run_id"] == "run_001"
+        assert message["node_id"] == "node_A"
+        assert "timestamp" in message
+        assert message["payload"]["artifact_hash"] == "sha256_abc123"
+
+    def test_publish_node_failed(self):
+        """Test publishing node_failed event via sync Redis."""
+        mock_redis = Mock()
+        mock_redis.publish = Mock()
+
+        _publish_event_sync(
+            redis_conn=mock_redis,
+            channel=CHANNEL_NODE_FAILED,
+            event_type="node_failed",
+            run_id="run_002",
+            node_id="node_B",
+            payload={
+                "error_code": "UPSTREAM_TIMEOUT",
+                "error_msg": "API call timed out after 60s",
+                "retry_count": 3
+            }
+        )
+
+        # Verify publish was called
+        assert mock_redis.publish.called
+        call_args = mock_redis.publish.call_args
+        assert call_args[0][0] == CHANNEL_NODE_FAILED
+
+        # Verify message structure
+        message = json.loads(call_args[0][1])
+        assert message["event_type"] == "node_failed"
+        assert message["payload"]["error_code"] == "UPSTREAM_TIMEOUT"
+
+
+class TestExecuteByType:
+    """Test job execution by type."""
+
+    def test_text_to_image(self):
+        """Test text_to_image job execution."""
+        result = _execute_by_type("text_to_image", {"prompt": "a cat"})
+        assert "artifact_hash" in result
+        assert "output_url" in result
+        assert "cost" in result
+        assert result["cost"] == 0.1
+
+    def test_image_to_video(self):
+        """Test image_to_video job execution."""
+        result = _execute_by_type("image_to_video", {"image_url": "http://example.com/img.png"})
+        assert "artifact_hash" in result
+        assert "duration" in result
+        assert result["cost"] == 1.5
+
+    def test_unknown_job_type_raises(self):
+        """Test unknown job type raises ValueError."""
+        with pytest.raises(ValueError, match="Unknown job type"):
+            _execute_by_type("unknown_type", {})
+
+
+class TestExecuteJobIntegration:
+    """Test execute_job with mocked RQ context (Issue #7 integration test)."""
+
+    @patch('cine_mate.infra.worker.get_current_job')
+    def test_execute_job_success_publishes_event(self, mock_get_current_job):
+        """Test successful job execution publishes node_completed event."""
+        # Mock RQ job and Redis connection
+        mock_job = Mock()
+        mock_redis = Mock()
+        mock_redis.hgetall = Mock(return_value={
+            "job_id": "test_job_001",
+            "run_id": "run_001",
+            "node_id": "node_A",
+            "job_type": "text_to_image",
+            "params": json.dumps({"prompt": "test"}),
+            "status": "queued"
+        })
+        mock_redis.hset = Mock()
+        mock_redis.publish = Mock()
+
+        mock_job.connection = mock_redis
+        mock_get_current_job.return_value = mock_job
+
+        # Execute job
+        execute_job("test_job_001")
+
+        # Verify status was updated to completed
+        hset_calls = mock_redis.hset.call_args_list
+        assert any("completed" in str(call) for call in hset_calls)
+
+        # Verify event was published
+        assert mock_redis.publish.called
+        publish_call = mock_redis.publish.call_args
+        assert publish_call[0][0] == CHANNEL_NODE_COMPLETED
+
+        message = json.loads(publish_call[0][1])
+        assert message["event_type"] == "node_completed"
+        assert message["run_id"] == "run_001"
+        assert message["node_id"] == "node_A"
+
+    @patch('cine_mate.infra.worker.get_current_job')
+    def test_execute_job_failure_publishes_event(self, mock_get_current_job):
+        """Test failed job execution publishes node_failed event."""
+        # Mock RQ job with invalid job type to trigger failure
+        mock_job = Mock()
+        mock_redis = Mock()
+        mock_redis.hgetall = Mock(return_value={
+            "job_id": "test_job_002",
+            "run_id": "run_002",
+            "node_id": "node_B",
+            "job_type": "invalid_type",  # Will trigger ValueError
+            "params": json.dumps({}),
+            "status": "queued"
+        })
+        mock_redis.hset = Mock()
+        mock_redis.publish = Mock()
+
+        mock_job.connection = mock_redis
+        mock_get_current_job.return_value = mock_job
+
+        # Execute job (should fail)
+        with pytest.raises(ValueError):
+            execute_job("test_job_002")
+
+        # Verify status was updated to failed
+        hset_calls = mock_redis.hset.call_args_list
+        assert any("failed" in str(call) for call in hset_calls)
+
+        # Verify error event was published
+        assert mock_redis.publish.called
+        publish_call = mock_redis.publish.call_args
+        assert publish_call[0][0] == CHANNEL_NODE_FAILED
+
+        message = json.loads(publish_call[0][1])
+        assert message["event_type"] == "node_failed"
+        assert message["payload"]["error_code"] == "EXECUTION_ERROR"
+
+
+class TestChannelNames:
+    """Test channel naming matches EventBus pattern."""
+
+    def test_channel_names_match_eventbus(self):
+        """Verify channel names follow cinemate:event_type pattern."""
+        assert CHANNEL_NODE_COMPLETED == "cinemate:node_completed"
+        assert CHANNEL_NODE_FAILED == "cinemate:node_failed"


### PR DESCRIPTION
## Summary

Fix Issue #7: RQ Worker execution failed with `RuntimeError: Not connected`

### Root Cause
- EventBus requires `await connect()` but Worker is sync (RQ requirement)
- `asyncio.run()` inside sync function caused connection issues
- Redis client type mismatch: JobQueue uses `redis.asyncio`, RQ uses `redis` (sync)

### Fix
- Added `_publish_event_sync()` helper using sync Redis API
- Worker now directly calls `redis_conn.publish()` (sync)
- Removed async EventBus dependency from Worker

## Changes

| File | Changes |
|------|---------|
| `cine_mate/infra/worker.py` | Replace async EventBus with sync Redis Pub/Sub |
| `tests/unit/infra/test_worker.py` | Unit tests for sync publish function |

## Test Plan

- [ ] Verify Worker can execute job without EventBus connection error
- [ ] Verify `node_completed` event is published to `cinemate:node_completed` channel
- [ ] Verify `node_failed` event is published on job failure
- [ ] Verify EventBus subscriber can receive events from Worker

## Verification

```bash
# Syntax verified
python3 -m py_compile cine_mate/infra/worker.py  # OK
python3 -m py_compile tests/unit/infra/test_worker.py  # OK
```

## Related

- Closes #7
- Related to #4 (Event-Driven dependency control)

🤖 Generated with [Claude Code](https://claude.com/claude-code)