### PR TITLE
fix(queue): Resolve sync/async Redis client mismatch

### DIFF
--- a/cine_mate/infra/queue.py
+++ b/cine_mate/infra/queue.py
@@ -14,7 +14,8 @@ import asyncio
 from typing import Optional, Dict, Any, Callable
 from datetime import datetime
 
-import redis.asyncio as redis
+import redis
+import redis.asyncio as async_redis
 from rq import Queue
 from rq.job import Job as RQJob
 
@@ -70,7 +71,7 @@ class JobQueue:
         event_bus: Optional[Any] = None  # EventBus instance
     ):
         self.redis_url = redis_url
-        self.redis: Optional[redis.Redis] = None
+        self.redis: Optional[async_redis.Redis] = None
         self.rq_queue: Optional[Queue] = None
         self.event_bus = event_bus
         self._connected = False
@@ -80,15 +81,15 @@ class JobQueue:
         if self._connected:
             return
         
-        self.redis = redis.from_url(
+        self.redis = async_redis.from_url(
             self.redis_url,
             encoding="utf-8",
             decode_responses=True
         )
         
-        # Initialize RQ Queue (sync)
-        sync_redis = redis.from_url(self.redis_url, decode_responses=True)
-        self.rq_queue = Queue(connection=sync_redis)
+        # Initialize RQ Queue using standard sync Redis client
+        sync_redis_client = redis.from_url(self.redis_url, decode_responses=True)
+        self.rq_queue = Queue(connection=sync_redis_client)
         
         self._connected = True
     


### PR DESCRIPTION
## Summary

Fixes the **'coroutine object is not subscriptable'** error when submitting jobs to the queue.

### Root Cause
The `JobQueue` was initializing RQ with `redis.asyncio`, which caused failures in RQ's internal synchronous operations (like version checking).

### Fix
- Import both `redis` (sync) and `redis.asyncio` (as `async_redis`).
- Use `async_redis` for the Queue's async metadata operations.
- Use standard sync `redis` for the RQ Queue connection.

## Test Plan
- [ ] Verify `submit_job` successfully enqueues tasks to Redis without `TypeError`
- [ ] Verify Worker picks up the new jobs
- [ ] Verify `node_completed` events are triggered

## Related
- Related to #7 (Worker connection issues)
- Resolves Sprint 1 Integration Testing block

🤖 Generated with [Hermes Agent]