### PR TITLE
feat(config): Add configuration system skeleton with multi-model profiles

### DIFF
--- a/cine_mate/config/__init__.py
+++ b/cine_mate/config/__init__.py
@@ -1,0 +1,27 @@
+"""CineMate Configuration Module"""
+
+from cine_mate.config.models import (
+    CineMateConfig,
+    ModelsConfig,
+    ModelProfile,
+    ModelTier,
+    InfraConfig,
+    AppConfig,
+    LLMProvider,
+    ImageProvider,
+    VideoProvider,
+    TTSProvider,
+)
+
+__all__ = [
+    "CineMateConfig",
+    "ModelsConfig",
+    "ModelProfile",
+    "ModelTier",
+    "InfraConfig",
+    "AppConfig",
+    "LLMProvider",
+    "ImageProvider",
+    "VideoProvider",
+    "TTSProvider",
+]

--- a/cine_mate/config/defaults.yaml
+++ b/cine_mate/config/defaults.yaml
@@ -1,0 +1,131 @@
+# CineMate Default Configuration
+# Override via environment variables or cine_mate.yaml in project root
+
+models:
+  # LLM: Director Agent, intent parsing, script generation
+  llm:
+    primary:
+      provider: dashscope_qwen
+      model_name: qwen-max
+      api_key_env: DASHSCOPE_API_KEY
+      max_retries: 2
+      timeout_seconds: 60
+    fallback:
+      provider: dashscope_qwen
+      model_name: qwen-plus
+      api_key_env: DASHSCOPE_API_KEY
+      max_retries: 3
+      timeout_seconds: 90
+    budget:
+      provider: dashscope_qwen
+      model_name: qwen-turbo
+      api_key_env: DASHSCOPE_API_KEY
+      max_retries: 2
+      timeout_seconds: 30
+
+  # Text -> Image
+  text_to_image:
+    primary:
+      provider: flux
+      model_name: flux-pro-1.1
+      api_key_env: FLUX_API_KEY
+      max_retries: 2
+      timeout_seconds: 120
+      extra:
+        width: 1024
+        height: 1024
+    fallback:
+      provider: dashscope_wanx
+      model_name: wanx-v2
+      api_key_env: DASHSCOPE_API_KEY
+      max_retries: 3
+      timeout_seconds: 180
+    budget:
+      provider: stable_diffusion
+      model_name: sd-xl
+      api_key_env: STABILITY_API_KEY
+      max_retries: 2
+      timeout_seconds: 90
+
+  # Image -> Video
+  image_to_video:
+    primary:
+      provider: kling
+      model_name: kling-v1.6-pro
+      api_key_env: KLING_API_KEY
+      max_retries: 2
+      timeout_seconds: 300
+      extra:
+        duration: 5
+        resolution: "720p"
+    fallback:
+      provider: luma
+      model_name: luma-dream-machine
+      api_key_env: LUMA_API_KEY
+      max_retries: 3
+      timeout_seconds: 240
+    budget:
+      provider: minimax
+      model_name: minimax-video-01
+      api_key_env: MINIMAX_API_KEY
+      max_retries: 2
+      timeout_seconds: 180
+
+  # Text -> Video (direct)
+  text_to_video:
+    primary:
+      provider: runway
+      model_name: runway-gen3-alpha
+      api_key_env: RUNWAY_API_KEY
+      max_retries: 2
+      timeout_seconds: 300
+    fallback:
+      provider: kling
+      model_name: kling-text2video
+      api_key_env: KLING_API_KEY
+      max_retries: 2
+      timeout_seconds: 300
+
+  # Text-to-Speech
+  tts:
+    primary:
+      provider: cosyvoice
+      model_name: cosyvoice-v2
+      api_key_env: DASHSCOPE_API_KEY
+      max_retries: 2
+      timeout_seconds: 60
+    fallback:
+      provider: elevenlabs
+      model_name: eleven-multilingual-v2
+      api_key_env: ELEVENLABS_API_KEY
+      max_retries: 2
+      timeout_seconds: 90
+
+  # Vision: Quality gate, visual analysis (optional)
+  vision:
+    primary:
+      provider: dashscope_qwen
+      model_name: qwen-vl-max
+      api_key_env: DASHSCOPE_API_KEY
+      max_retries: 2
+      timeout_seconds: 30
+    fallback:
+      provider: dashscope_qwen
+      model_name: qwen-vl-plus
+      api_key_env: DASHSCOPE_API_KEY
+      max_retries: 3
+      timeout_seconds: 60
+
+# Infrastructure defaults
+infra:
+  redis_url: "redis://localhost:6379"
+  db_path: "./cinemate.db"
+  cas_root: "./cinemate_cas"
+  queue_name: "default"
+  worker_timeout: 600
+
+# Application settings
+app:
+  log_level: "INFO"
+  enable_telemetry: false
+  max_concurrent_runs: 5

--- a/cine_mate/config/loader.py
+++ b/cine_mate/config/loader.py
@@ -1,0 +1,74 @@
+"""
+CineMate Config Loader (Skeleton)
+
+Sprint 2 TODO:
+- Load from YAML file
+- Override with environment variables
+- Validate API keys at startup
+- Support per-run model overrides
+
+Current: Loads defaults programmatically for validation.
+"""
+
+import os
+import yaml
+from pathlib import Path
+from typing import Optional
+
+from cine_mate.config.models import CineMateConfig, ModelProfile
+
+
+def load_config(config_path: Optional[str] = None) -> CineMateConfig:
+    """
+    Load CineMate configuration.
+    
+    Priority:
+    1. User config file (cine_mate.yaml)
+    2. Environment variable overrides (CINEMATE_*)
+    3. Built-in defaults
+    
+    Args:
+        config_path: Optional path to custom config YAML.
+                     Falls back to project root cine_mate.yaml or defaults.
+    """
+    # Sprint 2: Implement full loader
+    # For now, return validated defaults
+    defaults_path = Path(__file__).parent / "defaults.yaml"
+    
+    with open(defaults_path, "r") as f:
+        raw = yaml.safe_load(f)
+    
+    return CineMateConfig(**raw)
+
+
+def get_model_for_task(config: CineMateConfig, task: str) -> ModelProfile:
+    """
+    Get the primary model for a given task.
+    
+    Args:
+        config: Loaded CineMateConfig
+        task: One of "llm", "text_to_image", "image_to_video", 
+              "text_to_video", "tts", "vision"
+    
+    Returns:
+        ModelProfile for the primary provider
+    """
+    tier = getattr(config.models, task)
+    return tier.primary
+
+
+def get_model_by_cost(config: CineMateConfig, task: str, cost_tier: str = "primary") -> ModelProfile:
+    """
+    Get model by cost tier.
+    
+    Args:
+        cost_tier: "primary" (default), "fallback", or "budget"
+    """
+    tier = getattr(config.models, task)
+    if cost_tier == "primary":
+        return tier.primary
+    elif cost_tier == "fallback" and tier.fallback:
+        return tier.fallback
+    elif cost_tier == "budget" and tier.budget:
+        return tier.budget
+    return tier.primary

--- a/cine_mate/config/models.py
+++ b/cine_mate/config/models.py
@@ -1,0 +1,110 @@
+"""
+CineMate Configuration System
+
+Data Model First: Defines the configuration schema for all CineMate components.
+- Model profiles per use case (LLM, Image, Video, TTS, Vision)
+- Provider fallback chains for reliability
+- Cost-tier model selection (turbo/plus/max)
+
+Sprint 2 TODO:
+- Implement config loader (YAML + env override)
+- Integrate with DirectorAgent model selection
+- Add provider adapter pattern for upstream APIs
+"""
+
+from pydantic import BaseModel, Field
+from typing import Optional, Dict, Any, List
+from enum import Enum
+
+
+# =============================================================================
+# Model Provider Enum
+# =============================================================================
+
+class LLMProvider(str, Enum):
+    DASHSCOPE_QWEN = "dashscope_qwen"
+    OPENAI = "openai"
+    ANTHROPIC = "anthropic"
+    ZHIPU_GLM = "zhipu_glm"
+
+
+class ImageProvider(str, Enum):
+    FLUX = "flux"
+    MIDJOURNEY = "midjourney"
+    STABLE_DIFFUSION = "stable_diffusion"
+    DASHSCOPE_WANX = "dashscope_wanx"
+
+
+class VideoProvider(str, Enum):
+    KLING = "kling"
+    RUNWAY = "runway"
+    LUMA = "luma"
+    MINIMAX = "minimax"
+
+
+class TTSProvider(str, Enum):
+    COSYVOICE = "cosyvoice"
+    ELEVENLABS = "elevenlabs"
+    DASHSCOPE_SAMBERT = "dashscope_sambert"
+
+
+# =============================================================================
+# Model Profile Schema
+# =============================================================================
+
+class ModelProfile(BaseModel):
+    """Defines a model configuration for a specific task."""
+    provider: str
+    model_name: str
+    api_key_env: Optional[str] = None  # env var name
+    base_url: Optional[str] = None
+    max_retries: int = 2
+    timeout_seconds: int = 120
+    extra: Dict[str, Any] = Field(default_factory=dict)
+
+    class Config:
+        extra = "allow"
+
+
+class ModelTier(BaseModel):
+    """Multi-provider tier for fallback and cost optimization."""
+    primary: ModelProfile
+    fallback: Optional[ModelProfile] = None
+    budget: Optional[ModelProfile] = None  # Lower cost option
+
+
+# =============================================================================
+# CineMate Config Schema
+# =============================================================================
+
+class ModelsConfig(BaseModel):
+    """All model configurations for CineMate pipeline."""
+    llm: ModelTier  # Director Agent, script generation, intent parsing
+    text_to_image: ModelTier  # Text -> Image generation
+    image_to_video: ModelTier  # Image -> Video generation
+    text_to_video: ModelTier  # Direct Text -> Video
+    tts: ModelTier  # Text-to-Speech
+    vision: Optional[ModelTier] = None  # Quality gate, visual analysis
+
+
+class InfraConfig(BaseModel):
+    """Infrastructure configuration."""
+    redis_url: str = "redis://localhost:6379"
+    db_path: str = "./cinemate.db"
+    cas_root: str = "./cinemate_cas"
+    queue_name: str = "default"
+    worker_timeout: int = 600
+
+
+class AppConfig(BaseModel):
+    """Application-level settings."""
+    log_level: str = "INFO"
+    enable_telemetry: bool = False
+    max_concurrent_runs: int = 5
+
+
+class CineMateConfig(BaseModel):
+    """Root configuration for CineMate."""
+    models: ModelsConfig
+    infra: InfraConfig = Field(default_factory=InfraConfig)
+    app: AppConfig = Field(default_factory=AppConfig)


### PR DESCRIPTION
## Summary

配置系统骨架，遵循 **Data Model First** 原则。为 Sprint 2 完整实现奠定基础。

### 设计

每个任务类型拥有独立的 **ModelTier**（primary / fallback / budget）：

| 任务 | Primary | Fallback | Budget |
|------|---------|----------|--------|
| LLM | qwen-max | qwen-plus | qwen-turbo |
| Text→Image | flux-pro | wanx-v2 | sd-xl |
| Image→Video | kling-v1.6-pro | luma | minimax |
| Text→Video | runway-gen3 | kling-t2v | - |
| TTS | cosyvoice-v2 | elevenlabs | - |
| Vision (质检) | qwen-vl-max | qwen-vl-plus | - |

### 文件清单
- `cine_mate/config/models.py` — Pydantic 数据模型
- `cine_mate/config/defaults.yaml` — 默认配置
- `cine_mate/config/loader.py` — 加载器骨架（Sprint 2 完善）
- `cine_mate/config/__init__.py` — 模块导出

### Sprint 2 TODO
- [ ] 环境变量覆盖加载 (CINEMATE_*)
- [ ] API Key 启动时验证
- [ ] 与 DirectorAgent 集成
- [ ] 运行时 per-run 模型覆盖

## Related
- Closes Sprint 2 首个任务
- 不影响 Sprint 1 Demo 运行（纯新增模块）

🤖 Generated with [Hermes Agent]