### PR TITLE
feat(adapters): Implement Kling, Runway, and Mock Video Providers

### DIFF
--- a/cine_mate/adapters/__init__.py
+++ b/cine_mate/adapters/__init__.py
@@ -1,0 +1,13 @@
+"""CineMate Provider Adapters"""
+
+from cine_mate.adapters.base import (
+    BaseVideoProvider,
+    VideoGenerationResult,
+    ProviderError,
+)
+
+__all__ = [
+    "BaseVideoProvider",
+    "VideoGenerationResult",
+    "ProviderError",
+]

--- a/cine_mate/adapters/base.py
+++ b/cine_mate/adapters/base.py
@@ -1,0 +1,189 @@
+"""
+CineMate Provider Adapter Base Classes
+
+Defines the abstract interface for all video/image generation providers.
+Each provider (Kling, Runway, Luma, etc.) implements this interface.
+"""
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
+from typing import Optional, Dict, Any
+from datetime import datetime
+from enum import Enum
+
+
+class ProviderError(Exception):
+    """Raised when a provider operation fails."""
+    pass
+
+
+class ProviderStatus(str, Enum):
+    """Status of a video generation job."""
+    PENDING = "pending"
+    PROCESSING = "processing"
+    COMPLETED = "completed"
+    FAILED = "failed"
+
+
+@dataclass
+class VideoGenerationResult:
+    """Result of a video generation request."""
+    job_id: str
+    status: str
+    video_url: Optional[str] = None
+    thumbnail_url: Optional[str] = None
+    cost: float = 0.0
+    duration: int = 0
+    resolution: str = "720p"
+    created_at: datetime = field(default_factory=datetime.now)
+    extra: Dict[str, Any] = field(default_factory=dict)
+
+    @property
+    def is_completed(self) -> bool:
+        return self.status == ProviderStatus.COMPLETED
+
+    @property
+    def is_failed(self) -> bool:
+        return self.status == ProviderStatus.FAILED
+
+
+class BaseVideoProvider(ABC):
+    """
+    Abstract base class for all video generation providers.
+    
+    Each provider (Kling, Runway, Luma, etc.) must implement:
+    - generate_video: Submit a generation job
+    - estimate_cost: Estimate cost before generation
+    - check_status: Poll job status
+    - get_result: Retrieve completed video
+    """
+    
+    provider_name: str = "base"
+    
+    def __init__(self, api_key: str, **kwargs):
+        self.api_key = api_key
+        self.extra_config = kwargs
+    
+    @abstractmethod
+    async def generate_video(
+        self,
+        prompt: str,
+        duration: int = 10,
+        resolution: str = "720p",
+        image_url: Optional[str] = None,
+        **kwargs
+    ) -> VideoGenerationResult:
+        """
+        Submit a video generation job.
+        
+        Args:
+            prompt: Text description of the video
+            duration: Desired duration in seconds
+            resolution: Output resolution (e.g., "720p", "1080p")
+            image_url: Optional source image for image-to-video
+            **kwargs: Provider-specific parameters
+        
+        Returns:
+            VideoGenerationResult with job_id and initial status
+        """
+        pass
+    
+    @abstractmethod
+    def estimate_cost(self, duration: int, resolution: str = "720p") -> float:
+        """
+        Estimate cost for video generation.
+        
+        Args:
+            duration: Duration in seconds
+            resolution: Output resolution
+        
+        Returns:
+            Estimated cost in the provider's currency (usually USD)
+        """
+        pass
+    
+    @abstractmethod
+    async def check_status(self, job_id: str) -> str:
+        """
+        Check the status of a generation job.
+        
+        Args:
+            job_id: Job identifier from generate_video()
+        
+        Returns:
+            Status string: "pending", "processing", "completed", "failed"
+        """
+        pass
+    
+    @abstractmethod
+    async def get_result(self, job_id: str) -> Optional[VideoGenerationResult]:
+        """
+        Retrieve the final result of a completed job.
+        
+        Args:
+            job_id: Job identifier
+        
+        Returns:
+            VideoGenerationResult with video_url if completed, None otherwise
+        """
+        pass
+    
+    async def generate_and_wait(
+        self,
+        prompt: str,
+        duration: int = 10,
+        resolution: str = "720p",
+        image_url: Optional[str] = None,
+        poll_interval: int = 5,
+        max_wait: int = 600,
+        **kwargs
+    ) -> VideoGenerationResult:
+        """
+        Convenience method: submit job and poll until completion.
+        
+        Args:
+            prompt: Text description
+            duration: Duration in seconds
+            resolution: Output resolution
+            image_url: Optional source image
+            poll_interval: Seconds between status checks
+            max_wait: Maximum seconds to wait
+            **kwargs: Provider-specific parameters
+        
+        Returns:
+            VideoGenerationResult with video_url
+        
+        Raises:
+            ProviderError: If job fails or times out
+        """
+        import asyncio
+        
+        result = await self.generate_video(
+            prompt=prompt,
+            duration=duration,
+            resolution=resolution,
+            image_url=image_url,
+            **kwargs
+        )
+        
+        job_id = result.job_id
+        elapsed = 0
+        
+        while elapsed < max_wait:
+            await asyncio.sleep(poll_interval)
+            elapsed += poll_interval
+            
+            status = await self.check_status(job_id)
+            
+            if status == ProviderStatus.COMPLETED:
+                final = await self.get_result(job_id)
+                if final:
+                    return final
+                raise ProviderError(f"Job {job_id} completed but result retrieval failed")
+            
+            if status == ProviderStatus.FAILED:
+                raise ProviderError(f"Job {job_id} failed during generation")
+        
+        raise ProviderError(
+            f"Job {job_id} timed out after {max_wait}s"
+        )

--- a/cine_mate/adapters/kling_provider.py
+++ b/cine_mate/adapters/kling_provider.py
@@ -1,0 +1,192 @@
+"""
+Kling AI Video Generation Provider
+
+Adapts the Kling API (via WaveSpeed or direct) to CineMate's BaseVideoProvider interface.
+Supports:
+- text-to-video: Generate video from text prompt
+- image-to-video: Animate a still image
+
+API Reference: https://open.kuaishou.com/
+"""
+
+import os
+import asyncio
+from typing import Optional, Dict, Any
+from datetime import datetime
+
+import aiohttp
+
+from cine_mate.adapters.base import (
+    BaseVideoProvider,
+    VideoGenerationResult,
+    ProviderError,
+    ProviderStatus,
+)
+
+# Kling API endpoints (WaveSpeed proxy)
+KLING_BASE_URL = "https://api.wavespeed.ai/v1"
+KLING_MODEL_T2V = "kling-v2"
+KLING_MODEL_I2V = "kling-v2-i2v"
+
+# Pricing: ~$0.075/s for Kling 2.x (720p)
+KLING_COST_PER_SECOND = {
+    "720p": 0.075,
+    "1080p": 0.15,
+}
+
+
+class KlingProvider(BaseVideoProvider):
+    """
+    Kling AI Video Generation Provider.
+    
+    Usage:
+        provider = KlingProvider(api_key=os.getenv("KLING_API_KEY"))
+        result = await provider.generate_video(
+            prompt="A cyberpunk city at night with neon lights",
+            duration=10,
+            resolution="720p"
+        )
+    """
+    
+    provider_name = "kling"
+    
+    def __init__(
+        self,
+        api_key: Optional[str] = None,
+        base_url: str = KLING_BASE_URL,
+        model: str = KLING_MODEL_T2V,
+        **kwargs
+    ):
+        resolved_key = api_key or os.getenv("KLING_API_KEY")
+        if not resolved_key:
+            raise ProviderError(
+                "KLING_API_KEY not set. "
+                "Please set the environment variable or pass api_key parameter."
+            )
+        super().__init__(api_key=resolved_key, **kwargs)
+        self.base_url = base_url
+        self.model = model
+    
+    async def generate_video(
+        self,
+        prompt: str,
+        duration: int = 10,
+        resolution: str = "720p",
+        image_url: Optional[str] = None,
+        **kwargs
+    ) -> VideoGenerationResult:
+        """
+        Submit a video generation job to Kling.
+        
+        Args:
+            prompt: Text description of the video
+            duration: Duration in seconds (5, 10)
+            resolution: Output resolution ("720p", "1080p")
+            image_url: Optional source image for image-to-video mode
+            **kwargs: Additional parameters (negative_prompt, seed, etc.)
+        """
+        mode = "image_to_video" if image_url else "text_to_video"
+        model = KLING_MODEL_I2V if image_url else KLING_MODEL_T2V
+        
+        payload = {
+            "model": model,
+            "prompt": prompt,
+            "duration": duration,
+            "resolution": resolution,
+            "mode": mode,
+        }
+        
+        if image_url:
+            payload["image_url"] = image_url
+        
+        # Add optional parameters
+        if "negative_prompt" in kwargs:
+            payload["negative_prompt"] = kwargs["negative_prompt"]
+        if "seed" in kwargs:
+            payload["seed"] = kwargs["seed"]
+        
+        async with aiohttp.ClientSession() as session:
+            try:
+                async with session.post(
+                    f"{self.base_url}/video/generation",
+                    headers={
+                        "Authorization": f"Bearer {self.api_key}",
+                        "Content-Type": "application/json",
+                    },
+                    json=payload,
+                ) as response:
+                    if response.status != 200:
+                        error_body = await response.text()
+                        raise ProviderError(
+                            f"Kling API error {response.status}: {error_body}"
+                        )
+                    
+                    data = await response.json()
+                    
+                    return VideoGenerationResult(
+                        job_id=data.get("job_id", ""),
+                        status=data.get("status", ProviderStatus.PENDING),
+                        video_url=None,
+                        thumbnail_url=None,
+                        cost=self.estimate_cost(duration, resolution),
+                        duration=duration,
+                        resolution=resolution,
+                        extra={"mode": mode, "model": model},
+                    )
+            except aiohttp.ClientError as e:
+                raise ProviderError(f"Kling API connection error: {e}")
+    
+    def estimate_cost(self, duration: int, resolution: str = "720p") -> float:
+        """Estimate Kling video generation cost."""
+        rate = KLING_COST_PER_SECOND.get(resolution, KLING_COST_PER_SECOND["720p"])
+        return duration * rate
+    
+    async def check_status(self, job_id: str) -> str:
+        """Check the status of a Kling generation job."""
+        async with aiohttp.ClientSession() as session:
+            try:
+                async with session.get(
+                    f"{self.base_url}/video/status/{job_id}",
+                    headers={"Authorization": f"Bearer {self.api_key}"},
+                ) as response:
+                    if response.status != 200:
+                        raise ProviderError(
+                            f"Kling status check error {response.status}"
+                        )
+                    
+                    data = await response.json()
+                    return data.get("status", ProviderStatus.PENDING)
+            except aiohttp.ClientError as e:
+                raise ProviderError(f"Kling status check connection error: {e}")
+    
+    async def get_result(self, job_id: str) -> Optional[VideoGenerationResult]:
+        """Retrieve the completed video result from Kling."""
+        status = await self.check_status(job_id)
+        
+        if status != ProviderStatus.COMPLETED:
+            return None
+        
+        async with aiohttp.ClientSession() as session:
+            try:
+                async with session.get(
+                    f"{self.base_url}/video/result/{job_id}",
+                    headers={"Authorization": f"Bearer {self.api_key}"},
+                ) as response:
+                    if response.status != 200:
+                        raise ProviderError(
+                            f"Kling result fetch error {response.status}"
+                        )
+                    
+                    data = await response.json()
+                    
+                    return VideoGenerationResult(
+                        job_id=job_id,
+                        status=ProviderStatus.COMPLETED,
+                        video_url=data.get("video_url"),
+                        thumbnail_url=data.get("thumbnail_url"),
+                        cost=self.estimate_cost(data.get("duration", 10)),
+                        duration=data.get("duration", 10),
+                        resolution=data.get("resolution", "720p"),
+                    )
+            except aiohttp.ClientError as e:
+                raise ProviderError(f"Kling result fetch connection error: {e}")

--- a/cine_mate/adapters/mock_provider.py
+++ b/cine_mate/adapters/mock_provider.py
@@ -1,0 +1,107 @@
+"""
+Mock Video Provider for Testing
+
+Returns preset results without calling any real API.
+Useful for testing without API keys or spending credits.
+"""
+
+import asyncio
+from typing import Optional
+from datetime import datetime
+
+from cine_mate.adapters.base import (
+    BaseVideoProvider,
+    VideoGenerationResult,
+    ProviderStatus,
+)
+
+
+class MockVideoProvider(BaseVideoProvider):
+    """
+    Mock video provider for testing.
+    
+    Simulates video generation with instant or delayed preset results.
+    """
+    
+    provider_name = "mock"
+    
+    MOCK_VIDEO_URL = "https://example.com/mock_video.mp4"
+    MOCK_THUMBNAIL_URL = "https://example.com/mock_thumbnail.jpg"
+    
+    def __init__(self, simulate_delay: bool = False, delay_seconds: int = 2):
+        """
+        Args:
+            simulate_delay: If True, simulate API processing time
+            delay_seconds: Seconds to wait when simulating delay
+        """
+        super().__init__(api_key="mock_key")
+        self.simulate_delay = simulate_delay
+        self.delay_seconds = delay_seconds
+        self._jobs = {}  # Simulated job storage
+    
+    async def generate_video(
+        self,
+        prompt: str,
+        duration: int = 10,
+        resolution: str = "720p",
+        image_url: Optional[str] = None,
+        **kwargs
+    ) -> VideoGenerationResult:
+        """Simulate submitting a video generation job."""
+        import uuid
+        job_id = f"mock_{uuid.uuid4().hex[:8]}"
+        
+        mode = "image_to_video" if image_url else "text_to_video"
+        
+        result = VideoGenerationResult(
+            job_id=job_id,
+            status=ProviderStatus.PENDING,
+            video_url=None,
+            thumbnail_url=None,
+            cost=0.0,  # Free
+            duration=duration,
+            resolution=resolution,
+            extra={"mode": mode, "prompt": prompt, "provider": "mock"},
+        )
+        
+        self._jobs[job_id] = {
+            "result": result,
+            "status": ProviderStatus.PROCESSING,
+            "prompt": prompt,
+        }
+        
+        if self.simulate_delay:
+            await asyncio.sleep(self.delay_seconds)
+        
+        # Mark as completed instantly for mock
+        self._jobs[job_id]["status"] = ProviderStatus.COMPLETED
+        self._jobs[job_id]["result"] = VideoGenerationResult(
+            job_id=job_id,
+            status=ProviderStatus.COMPLETED,
+            video_url=self.MOCK_VIDEO_URL,
+            thumbnail_url=self.MOCK_THUMBNAIL_URL,
+            cost=0.0,
+            duration=duration,
+            resolution=resolution,
+            extra={"mode": mode, "prompt": prompt, "provider": "mock"},
+        )
+        
+        return result
+    
+    def estimate_cost(self, duration: int, resolution: str = "720p") -> float:
+        """Mock videos are always free."""
+        return 0.0
+    
+    async def check_status(self, job_id: str) -> str:
+        """Check mock job status."""
+        job = self._jobs.get(job_id)
+        if not job:
+            return ProviderStatus.FAILED
+        return job["status"]
+    
+    async def get_result(self, job_id: str) -> Optional[VideoGenerationResult]:
+        """Retrieve mock video result."""
+        job = self._jobs.get(job_id)
+        if not job:
+            return None
+        return job["result"]

--- a/cine_mate/adapters/runway_provider.py
+++ b/cine_mate/adapters/runway_provider.py
@@ -1,0 +1,203 @@
+"""
+Runway ML Video Generation Provider
+
+Adapts the Runway Gen-4 API to CineMate's BaseVideoProvider interface.
+Supports:
+- text-to-video: Generate video from text prompt
+
+API Reference: https://runwayml.com/
+"""
+
+import os
+from typing import Optional, Dict, Any
+from datetime import datetime
+
+import aiohttp
+
+from cine_mate.adapters.base import (
+    BaseVideoProvider,
+    VideoGenerationResult,
+    ProviderError,
+    ProviderStatus,
+)
+
+# Runway API endpoints
+RUNWAY_BASE_URL = "https://api.runwayml.com/v1"
+RUNWAY_MODEL = "gen4"
+
+# Pricing: ~$0.05/s for Runway Gen-4
+RUNWAY_COST_PER_SECOND = {
+    "720p": 0.05,
+    "1080p": 0.10,
+}
+
+
+class RunwayProvider(BaseVideoProvider):
+    """
+    Runway ML Video Generation Provider.
+    
+    Usage:
+        provider = RunwayProvider(api_key=os.getenv("RUNWAY_API_KEY"))
+        result = await provider.generate_video(
+            prompt="A cyberpunk city at night with neon lights",
+            duration=10,
+            resolution="720p"
+        )
+    """
+    
+    provider_name = "runway"
+    
+    def __init__(
+        self,
+        api_key: Optional[str] = None,
+        base_url: str = RUNWAY_BASE_URL,
+        model: str = RUNWAY_MODEL,
+        **kwargs
+    ):
+        resolved_key = api_key or os.getenv("RUNWAY_API_KEY")
+        if not resolved_key:
+            raise ProviderError(
+                "RUNWAY_API_KEY not set. "
+                "Please set the environment variable or pass api_key parameter."
+            )
+        super().__init__(api_key=resolved_key, **kwargs)
+        self.base_url = base_url
+        self.model = model
+    
+    async def generate_video(
+        self,
+        prompt: str,
+        duration: int = 10,
+        resolution: str = "720p",
+        image_url: Optional[str] = None,
+        **kwargs
+    ) -> VideoGenerationResult:
+        """
+        Submit a text-to-video generation job to Runway.
+        
+        Note: Runway Gen-4 supports text-to-video primarily.
+        Image-to-video may be supported in future API versions.
+        """
+        payload = {
+            "model": self.model,
+            "prompt": prompt,
+            "duration": duration,
+            "resolution": resolution,
+        }
+        
+        if image_url:
+            # Runway may support image-to-video in the future
+            payload["image_url"] = image_url
+        
+        if "seed" in kwargs:
+            payload["seed"] = kwargs["seed"]
+        if "style" in kwargs:
+            payload["style"] = kwargs["style"]
+        
+        async with aiohttp.ClientSession() as session:
+            try:
+                async with session.post(
+                    f"{self.base_url}/video/generation",
+                    headers={
+                        "Authorization": f"Bearer {self.api_key}",
+                        "Content-Type": "application/json",
+                        "X-Runway-Version": "2024-11-06",
+                    },
+                    json=payload,
+                ) as response:
+                    if response.status not in (200, 201, 202):
+                        error_body = await response.text()
+                        raise ProviderError(
+                            f"Runway API error {response.status}: {error_body}"
+                        )
+                    
+                    data = await response.json()
+                    
+                    return VideoGenerationResult(
+                        job_id=data.get("id", data.get("job_id", "")),
+                        status=data.get("status", ProviderStatus.PENDING),
+                        video_url=None,
+                        thumbnail_url=None,
+                        cost=self.estimate_cost(duration, resolution),
+                        duration=duration,
+                        resolution=resolution,
+                        extra={"model": self.model},
+                    )
+            except aiohttp.ClientError as e:
+                raise ProviderError(f"Runway API connection error: {e}")
+    
+    def estimate_cost(self, duration: int, resolution: str = "720p") -> float:
+        """Estimate Runway video generation cost."""
+        rate = RUNWAY_COST_PER_SECOND.get(resolution, RUNWAY_COST_PER_SECOND["720p"])
+        return duration * rate
+    
+    async def check_status(self, job_id: str) -> str:
+        """Check the status of a Runway generation job."""
+        async with aiohttp.ClientSession() as session:
+            try:
+                async with session.get(
+                    f"{self.base_url}/video/{job_id}",
+                    headers={
+                        "Authorization": f"Bearer {self.api_key}",
+                        "X-Runway-Version": "2024-11-06",
+                    },
+                ) as response:
+                    if response.status != 200:
+                        raise ProviderError(
+                            f"Runway status check error {response.status}"
+                        )
+                    
+                    data = await response.json()
+                    # Map Runway status to our enum
+                    runway_status = data.get("status", "pending")
+                    status_map = {
+                        "PENDING": ProviderStatus.PENDING,
+                        "RUNNING": ProviderStatus.PROCESSING,
+                        "SUCCEEDED": ProviderStatus.COMPLETED,
+                        "FAILED": ProviderStatus.FAILED,
+                    }
+                    return status_map.get(runway_status, runway_status.lower())
+            except aiohttp.ClientError as e:
+                raise ProviderError(f"Runway status check connection error: {e}")
+    
+    async def get_result(self, job_id: str) -> Optional[VideoGenerationResult]:
+        """Retrieve the completed video result from Runway."""
+        async with aiohttp.ClientSession() as session:
+            try:
+                async with session.get(
+                    f"{self.base_url}/video/{job_id}",
+                    headers={
+                        "Authorization": f"Bearer {self.api_key}",
+                        "X-Runway-Version": "2024-11-06",
+                    },
+                ) as response:
+                    if response.status != 200:
+                        raise ProviderError(
+                            f"Runway result fetch error {response.status}"
+                        )
+                    
+                    data = await response.json()
+                    status = data.get("status", "")
+                    
+                    if status not in ("SUCCEEDED", "completed"):
+                        return None
+                    
+                    output = data.get("output", {})
+                    if isinstance(output, dict):
+                        video_url = output.get("video", output.get("url"))
+                    elif isinstance(output, list):
+                        video_url = output[0] if output else None
+                    else:
+                        video_url = output
+                    
+                    return VideoGenerationResult(
+                        job_id=job_id,
+                        status=ProviderStatus.COMPLETED,
+                        video_url=video_url,
+                        thumbnail_url=data.get("preview"),
+                        cost=self.estimate_cost(data.get("duration", 10)),
+                        duration=data.get("duration", 10),
+                        resolution=data.get("resolution", "720p"),
+                    )
+            except aiohttp.ClientError as e:
+                raise ProviderError(f"Runway result fetch connection error: {e}")

--- a/cine_mate/infra/schemas.py
+++ b/cine_mate/infra/schemas.py
@@ -94,6 +94,12 @@ class JobType(str, Enum):
     TEXT_TO_VIDEO = "text_to_video"
     TTS = "tts"
     VIDEO_EDIT = "video_edit"
+    # Provider-specific job types (Sprint 2 Day 3)
+    KLING_TEXT_TO_VIDEO = "kling_text_to_video"
+    KLING_IMAGE_TO_VIDEO = "kling_image_to_video"
+    RUNWAY_TEXT_TO_VIDEO = "runway_text_to_video"
+    MOCK_TEXT_TO_VIDEO = "mock_text_to_video"
+    MOCK_IMAGE_TO_VIDEO = "mock_image_to_video"
 
 
 class Job(BaseModel):

--- a/cine_mate/infra/worker.py
+++ b/cine_mate/infra/worker.py
@@ -176,12 +176,19 @@ def _execute_by_type(job_type: str, params: Dict[str, Any]) -> Dict[str, Any]:
     """
     Execute job based on type.
     
-    This is where you'd call the actual upstream APIs.
-    For now, it's a placeholder that simulates execution.
+    Routes to the appropriate Provider or mock handler.
     """
     import time
-    time.sleep(2)  # Simulate API call delay
     
+    # Provider-based video generation
+    if job_type in ("kling_text_to_video", "kling_image_to_video"):
+        return _execute_kling(job_type, params)
+    elif job_type == "runway_text_to_video":
+        return _execute_runway(params)
+    elif job_type in ("mock_text_to_video", "mock_image_to_video"):
+        return _execute_mock(job_type, params)
+    
+    # Legacy handlers
     if job_type == "text_to_image":
         return _text_to_image(params)
     elif job_type == "image_to_video":
@@ -259,6 +266,103 @@ def _video_edit(params: Dict[str, Any]) -> Dict[str, Any]:
         "output_url": "https://example.com/edited_video.mp4",
         "operation": operation,
         "cost": 0.5,
+    }
+
+
+# =============================================================================
+# Provider-based execution functions (Sprint 2 Day 3)
+# =============================================================================
+
+def _execute_kling(job_type: str, params: Dict[str, Any]) -> Dict[str, Any]:
+    """Execute Kling video generation job (sync wrapper for async provider)."""
+    import asyncio
+    from cine_mate.adapters.kling_provider import KlingProvider
+    
+    prompt = params.get("prompt", "")
+    duration = params.get("duration", 10)
+    resolution = params.get("resolution", "720p")
+    image_url = params.get("image_url")
+    
+    print(f"[Worker] Kling {job_type}: prompt='{prompt[:50]}...', duration={duration}s")
+    
+    provider = KlingProvider()
+    result = asyncio.run(provider.generate_and_wait(
+        prompt=prompt,
+        duration=duration,
+        resolution=resolution,
+        image_url=image_url,
+        poll_interval=5,
+        max_wait=params.get("max_wait", 300),
+    ))
+    
+    return {
+        "artifact_hash": f"kling_{result.job_id}",
+        "output_url": result.video_url,
+        "thumbnail_url": result.thumbnail_url,
+        "duration": result.duration,
+        "cost": result.cost,
+        "provider": "kling",
+        "job_id": result.job_id,
+    }
+
+
+def _execute_runway(params: Dict[str, Any]) -> Dict[str, Any]:
+    """Execute Runway video generation job (sync wrapper for async provider)."""
+    import asyncio
+    from cine_mate.adapters.runway_provider import RunwayProvider
+    
+    prompt = params.get("prompt", "")
+    duration = params.get("duration", 10)
+    resolution = params.get("resolution", "720p")
+    
+    print(f"[Worker] Runway text_to_video: prompt='{prompt[:50]}...', duration={duration}s")
+    
+    provider = RunwayProvider()
+    result = asyncio.run(provider.generate_and_wait(
+        prompt=prompt,
+        duration=duration,
+        resolution=resolution,
+        poll_interval=5,
+        max_wait=params.get("max_wait", 300),
+    ))
+    
+    return {
+        "artifact_hash": f"runway_{result.job_id}",
+        "output_url": result.video_url,
+        "thumbnail_url": result.thumbnail_url,
+        "duration": result.duration,
+        "cost": result.cost,
+        "provider": "runway",
+        "job_id": result.job_id,
+    }
+
+
+def _execute_mock(job_type: str, params: Dict[str, Any]) -> Dict[str, Any]:
+    """Execute Mock video generation job (for testing without API keys)."""
+    import asyncio
+    from cine_mate.adapters.mock_provider import MockVideoProvider
+    
+    prompt = params.get("prompt", "")
+    duration = params.get("duration", 10)
+    resolution = params.get("resolution", "720p")
+    
+    print(f"[Worker] Mock {job_type}: prompt='{prompt[:50]}...', duration={duration}s")
+    
+    provider = MockVideoProvider(simulate_delay=True, delay_seconds=2)
+    result = asyncio.run(provider.generate_and_wait(
+        prompt=prompt,
+        duration=duration,
+        resolution=resolution,
+    ))
+    
+    return {
+        "artifact_hash": f"mock_{result.job_id}",
+        "output_url": result.video_url,
+        "thumbnail_url": result.thumbnail_url,
+        "duration": result.duration,
+        "cost": 0.0,
+        "provider": "mock",
+        "job_id": result.job_id,
     }
 
 


### PR DESCRIPTION
## Summary

Sprint 2 Day 3: Provider 适配器实现，完成 Video 生成集成。

### 新增文件
- `cine_mate/adapters/base.py` — BaseVideoProvider 抽象基类 + VideoGenerationResult
- `cine_mate/adapters/kling_provider.py` — Kling AI Provider (T2V + I2V)
- `cine_mate/adapters/runway_provider.py` — Runway Gen-4 Provider (T2V)
- `cine_mate/adapters/mock_provider.py` — Mock Provider (无 API Key 测试)

### 修改文件
- `cine_mate/infra/schemas.py` — JobType 扩展 (KLING_TEXT_TO_VIDEO, etc.)
- `cine_mate/infra/worker.py` — Worker 路由到对应 Provider

### 功能清单
- [x] BaseVideoProvider 抽象基类
- [x] KlingProvider: text-to-video + image-to-video
- [x] RunwayProvider: text-to-video
- [x] MockVideoProvider: 无 API Key 可测试
- [x] JobType 扩展
- [x] Worker 调用 Provider
- [x] generate_and_wait 便捷方法 (自动轮询)
- [x] 成本估算 per provider
- [x] 原有 Demo 测试通过

### 验收
- Demo 测试通过: `python scripts/demo_day5.py` ✅

Closes Sprint 2 Day 3 tasks