### PR TITLE
refactor(engine)[P0]: Add JobQueue-Engine integration layer (Issue #29)

### DIFF
--- a/cine_mate/engine/__init__.py
+++ b/cine_mate/engine/__init__.py
@@ -1,1 +1,15 @@
-# Empty init
+"""
+CineMate Engine Module
+
+Core orchestration and execution engine for video production workflows.
+"""
+
+from cine_mate.engine.queue_integration import (
+    JobQueueAdapter,
+    create_engine_queue_integration,
+)
+
+__all__ = [
+    "JobQueueAdapter",
+    "create_engine_queue_integration",
+]

--- a/cine_mate/engine/queue_integration.py
+++ b/cine_mate/engine/queue_integration.py
@@ -1,0 +1,200 @@
+"""
+Engine-Queue Integration Layer
+
+Decouples Engine/Orchestrator from JobQueue implementation.
+Provides a clean interface for job submission and status tracking.
+
+Architecture:
+    Orchestrator → JobQueueAdapter → JobQueue → Worker
+         ↓                              ↓
+    FSM callbacks ← EventBus ← Event publishing
+"""
+
+from typing import Optional, Dict, Any, Callable
+from datetime import datetime
+
+from cine_mate.infra.queue import JobQueue
+from cine_mate.infra.event_bus import EventBus
+from cine_mate.infra.schemas import (
+    JobType,
+    JobStatus,
+    CineMateEvent,
+    NodeCompletedEvent,
+    NodeFailedEvent,
+)
+
+
+class JobQueueAdapter:
+    """
+    Adapter layer between Engine and JobQueue.
+    
+    Responsibilities:
+    1. Translate Engine job requests to JobQueue format
+    2. Subscribe to job completion events
+    3. Notify Engine callbacks on job status changes
+    
+    Usage:
+        adapter = JobQueueAdapter(job_queue, event_bus)
+        
+        # Submit job from Engine
+        job_id = await adapter.submit_node_job(
+            run_id="run_001",
+            node_id="img_gen_01",
+            job_type=JobType.TEXT_TO_IMAGE,
+            params={"prompt": "a cat"}
+        )
+        
+        # Register completion callback
+        adapter.on_job_complete(node_id, callback_fn)
+    """
+    
+    def __init__(
+        self,
+        job_queue: JobQueue,
+        event_bus: EventBus
+    ):
+        """
+        Initialize adapter.
+        
+        Args:
+            job_queue: JobQueue instance
+            event_bus: EventBus instance for event subscription
+        """
+        self.job_queue = job_queue
+        self.event_bus = event_bus
+        self._callbacks: Dict[str, Callable] = {}
+        
+        # Subscribe to job events
+        self._setup_event_handlers()
+    
+    def _setup_event_handlers(self):
+        """Setup event handlers for job completion/failure"""
+        self.event_bus.subscribe("node_completed", self._on_node_completed)
+        self.event_bus.subscribe("node_failed", self._on_node_failed)
+    
+    async def _on_node_completed(self, event: CineMateEvent):
+        """Handle node completed event"""
+        if isinstance(event, NodeCompletedEvent):
+            callback = self._callbacks.get(event.node_id)
+            if callback:
+                await callback(event)
+    
+    async def _on_node_failed(self, event: CineMateEvent):
+        """Handle node failed event"""
+        # Similar to completed, but for failures
+        if isinstance(event, NodeFailedEvent):
+            callback = self._callbacks.get(event.node_id)
+            if callback:
+                await callback(event)
+    
+    def on_job_complete(
+        self,
+        node_id: str,
+        callback: Callable
+    ):
+        """
+        Register callback for job completion.
+        
+        Args:
+            node_id: Node identifier
+            callback: Async callback function(event: CineMateEvent)
+        """
+        self._callbacks[node_id] = callback
+    
+    def on_job_fail(
+        self,
+        node_id: str,
+        callback: Callable
+    ):
+        """
+        Register callback for job failure.
+        
+        Args:
+            node_id: Node identifier
+            callback: Async callback function(event: CineMateEvent)
+        """
+        self._callbacks[node_id] = callback
+    
+    async def submit_node_job(
+        self,
+        run_id: str,
+        node_id: str,
+        job_type: JobType,
+        params: Dict[str, Any]
+    ) -> str:
+        """
+        Submit a job for a node.
+        
+        Args:
+            run_id: Run identifier
+            node_id: Node identifier
+            job_type: Type of job (TEXT_TO_IMAGE, IMAGE_TO_VIDEO, etc.)
+            params: Job parameters
+        
+        Returns:
+            Job ID for tracking
+        """
+        job_id = await self.job_queue.submit_job(
+            run_id=run_id,
+            node_id=node_id,
+            job_type=job_type,
+            params=params
+        )
+        return job_id
+    
+    async def get_job_status(self, job_id: str) -> JobStatus:
+        """
+        Get job status.
+        
+        Args:
+            job_id: Job identifier
+        
+        Returns:
+            JobStatus enum value
+        """
+        return await self.job_queue.get_job_status(job_id)
+    
+    async def cancel_job(self, job_id: str) -> bool:
+        """
+        Cancel a running job.
+        
+        Args:
+            job_id: Job identifier
+        
+        Returns:
+            True if cancelled, False otherwise
+        """
+        return await self.job_queue.cancel_job(job_id)
+    
+    async def get_all_jobs_status(self, run_id: str) -> Dict[str, JobStatus]:
+        """
+        Get status of all jobs in a run.
+        
+        Args:
+            run_id: Run identifier
+        
+        Returns:
+            Dict of job_id -> JobStatus
+        """
+        return await self.job_queue.get_all_jobs_status(run_id)
+
+
+async def create_engine_queue_integration(
+    redis_url: str = "redis://localhost:6379"
+) -> JobQueueAdapter:
+    """
+    Factory function to create Engine-Queue integration.
+    
+    Args:
+        redis_url: Redis connection URL
+    
+    Returns:
+        Configured JobQueueAdapter instance
+    """
+    job_queue = JobQueue(redis_url=redis_url)
+    event_bus = EventBus(redis_url=redis_url)
+    
+    await job_queue.connect()
+    await event_bus.connect()
+    
+    return JobQueueAdapter(job_queue, event_bus)

--- a/memory/2026-04-25.md
+++ b/memory/2026-04-25.md
@@ -1,0 +1,110 @@
+# 2026-04-25 Daily Standup
+
+> **Sprint**: 3 (2026-04-25 ~ 2026-04-29)  
+> **日期**: Day 1 (2026-04-25)  
+> **成员**: copaw (Infra & Skill 负责人)
+
+---
+
+## ✅ 今日完成
+
+### P0 - Issue #29 Sprint 3 架构改进 (3h)
+
+**Issue #29**: [refactor][P0] Sprint 3 架构改进 - Agents依赖注入+EventBus完整实现+JobQueue集成
+
+#### Part 1/3: JobQueue-Engine 集成层 ✅
+
+1. **JobQueueAdapter 实现** (1.5h)
+   - 解耦 Engine 与 JobQueue
+   - 事件驱动回调机制
+   - 支持 job complete/fail 回调注册
+   - 工厂函数：`create_engine_queue_integration()`
+
+2. **单元测试** (1h)
+   - 12 个测试用例
+   - 100% 通过率
+   - 覆盖率：81% (queue_integration.py)
+
+3. **PR 提交** (0.5h)
+   - **PR #30**: refactor(engine)[P0]: Add JobQueue-Engine integration layer
+   - 状态：⏳ Open for Review
+
+---
+
+## 📊 交付物
+
+| 文件 | 大小 | 内容 |
+|------|------|------|
+| `cine_mate/engine/queue_integration.py` | 5.4KB | JobQueueAdapter 实现 |
+| `cine_mate/engine/__init__.py` | 0.3KB | 导出更新 |
+| `tests/unit/engine/test_queue_integration.py` | 7.7KB | 12 单元测试 |
+
+---
+
+## 📈 测试结果
+
+```
+pytest tests/unit/engine/test_queue_integration.py -v
+=================== 12 passed, 2 warnings ====================
+
+Coverage:
+- queue_integration.py: 81%
+- Total: 23.51% (expected low for single module)
+```
+
+---
+
+## 🏗️ 架构改进
+
+### 之前 (紧耦合)
+```
+Orchestrator → JobQueue (direct call)
+```
+
+### 之后 (解耦)
+```
+Orchestrator → JobQueueAdapter → JobQueue → Worker
+     ↓                              ↓
+FSM callbacks ← EventBus ← Event publishing
+```
+
+---
+
+## 📅 明日计划 (Sprint 3 Day 2)
+
+### Part 2/3: EventBus 完整实现
+- [ ] 实现 `subscribe()` 异步订阅
+- [ ] 实现 `unsubscribe()` 退订
+- [ ] 实现 `publish()` 事件发布
+- [ ] 添加单元测试
+
+### Part 3/3: Agents 依赖注入完善
+- [ ] 抽象 LLM 接口
+- [ ] 补充 Agents 单元测试
+- [ ] 提升测试覆盖率至 75%
+
+---
+
+## 📝 Git 提交 & PRs
+
+### PRs Open
+| # | 标题 | 状态 |
+|---|------|------|
+| #30 | refactor(engine)[P0]: Add JobQueue-Engine integration layer | ⏳ Open |
+| #27 | docs(review)[P1]: Add Sprint 2 code review report | ⏳ Open |
+
+---
+
+## 🎯 Issue #29 进度
+
+| 部分 | 任务 | 状态 | PR |
+|------|------|------|-----|
+| Part 1/3 | JobQueue 集成层 | ✅ 完成 | #30 |
+| Part 2/3 | EventBus 完整实现 | ⏳ 进行中 | - |
+| Part 3/3 | Agents 依赖注入 | ⏳ 待开始 | - |
+
+---
+
+**Maintained by**: copaw  
+**Role**: Infra & Skill 负责人  
+**Sprint**: 3 Day 1 完成

--- a/tests/unit/engine/test_queue_integration.py
+++ b/tests/unit/engine/test_queue_integration.py
@@ -1,0 +1,245 @@
+"""
+Tests for Engine-Queue Integration Layer
+
+Test Coverage:
+- JobQueueAdapter creation and initialization
+- Event handler setup
+- Job submission
+- Callback registration
+- Status tracking
+"""
+
+import pytest
+import asyncio
+from unittest.mock import AsyncMock, Mock, patch
+
+from cine_mate.engine.queue_integration import (
+    JobQueueAdapter,
+    create_engine_queue_integration,
+)
+from cine_mate.infra.queue import JobQueue
+from cine_mate.infra.event_bus import EventBus
+from cine_mate.infra.schemas import (
+    JobType,
+    JobStatus,
+    NodeCompletedEvent,
+    NodeFailedEvent,
+)
+
+
+class TestJobQueueAdapter:
+    """Test JobQueueAdapter class."""
+    
+    def test_adapter_creation(self):
+        """Test adapter can be created."""
+        job_queue = Mock(spec=JobQueue)
+        event_bus = Mock(spec=EventBus)
+        
+        adapter = JobQueueAdapter(job_queue, event_bus)
+        
+        assert adapter.job_queue is job_queue
+        assert adapter.event_bus is event_bus
+        assert adapter._callbacks == {}
+    
+    def test_setup_event_handlers(self):
+        """Test event handlers are setup on init."""
+        job_queue = Mock(spec=JobQueue)
+        event_bus = Mock(spec=EventBus)
+        
+        adapter = JobQueueAdapter(job_queue, event_bus)
+        
+        # Should subscribe to node_completed and node_failed
+        assert event_bus.subscribe.call_count == 2
+        event_bus.subscribe.assert_any_call("node_completed", adapter._on_node_completed)
+        event_bus.subscribe.assert_any_call("node_failed", adapter._on_node_failed)
+    
+    @pytest.mark.asyncio
+    async def test_on_node_completed_calls_callback(self):
+        """Test callback is called on node completed."""
+        job_queue = Mock(spec=JobQueue)
+        event_bus = Mock(spec=EventBus)
+        
+        adapter = JobQueueAdapter(job_queue, event_bus)
+        
+        callback = AsyncMock()
+        adapter._callbacks["node_001"] = callback
+        
+        event = NodeCompletedEvent(
+            run_id="run_001",
+            node_id="node_001",
+            payload={
+                "artifact_hash": "abc123",
+                "output_url": "https://example.com/video.mp4",
+                "cost": 0.75
+            }
+        )
+        
+        await adapter._on_node_completed(event)
+        
+        callback.assert_called_once_with(event)
+    
+    @pytest.mark.asyncio
+    async def test_on_node_completed_no_callback(self):
+        """Test no error when no callback registered."""
+        job_queue = Mock(spec=JobQueue)
+        event_bus = Mock(spec=EventBus)
+        
+        adapter = JobQueueAdapter(job_queue, event_bus)
+        
+        event = NodeCompletedEvent(
+            run_id="run_001",
+            node_id="node_001",
+            payload={
+                "artifact_hash": "abc123",
+                "output_url": "https://example.com/video.mp4",
+                "cost": 0.0
+            }
+        )
+        
+        # Should not raise
+        await adapter._on_node_completed(event)
+    
+    @pytest.mark.asyncio
+    async def test_on_node_failed_calls_callback(self):
+        """Test callback is called on node failed."""
+        job_queue = Mock(spec=JobQueue)
+        event_bus = Mock(spec=EventBus)
+        
+        adapter = JobQueueAdapter(job_queue, event_bus)
+        
+        callback = AsyncMock()
+        adapter._callbacks["node_001"] = callback
+        
+        event = NodeFailedEvent(
+            run_id="run_001",
+            node_id="node_001",
+            payload={
+                "error_code": "TEST_ERROR",
+                "error_msg": "Test error",
+                "retry_count": 0
+            }
+        )
+        
+        await adapter._on_node_failed(event)
+        
+        callback.assert_called_once_with(event)
+    
+    def test_on_job_complete_registers_callback(self):
+        """Test callback registration for job completion."""
+        job_queue = Mock(spec=JobQueue)
+        event_bus = Mock(spec=EventBus)
+        
+        adapter = JobQueueAdapter(job_queue, event_bus)
+        
+        callback = AsyncMock()
+        adapter.on_job_complete("node_001", callback)
+        
+        assert adapter._callbacks["node_001"] is callback
+    
+    def test_on_job_fail_registers_callback(self):
+        """Test callback registration for job failure."""
+        job_queue = Mock(spec=JobQueue)
+        event_bus = Mock(spec=EventBus)
+        
+        adapter = JobQueueAdapter(job_queue, event_bus)
+        
+        callback = AsyncMock()
+        adapter.on_job_fail("node_001", callback)
+        
+        assert adapter._callbacks["node_001"] is callback
+    
+    @pytest.mark.asyncio
+    async def test_submit_node_job(self):
+        """Test job submission."""
+        job_queue = Mock(spec=JobQueue)
+        job_queue.submit_job = AsyncMock(return_value="job_001")
+        event_bus = Mock(spec=EventBus)
+        
+        adapter = JobQueueAdapter(job_queue, event_bus)
+        
+        job_id = await adapter.submit_node_job(
+            run_id="run_001",
+            node_id="node_001",
+            job_type=JobType.TEXT_TO_IMAGE,
+            params={"prompt": "a cat"}
+        )
+        
+        assert job_id == "job_001"
+        job_queue.submit_job.assert_called_once_with(
+            run_id="run_001",
+            node_id="node_001",
+            job_type=JobType.TEXT_TO_IMAGE,
+            params={"prompt": "a cat"}
+        )
+    
+    @pytest.mark.asyncio
+    async def test_get_job_status(self):
+        """Test getting job status."""
+        job_queue = Mock(spec=JobQueue)
+        job_queue.get_job_status = AsyncMock(return_value=JobStatus.COMPLETED)
+        event_bus = Mock(spec=EventBus)
+        
+        adapter = JobQueueAdapter(job_queue, event_bus)
+        
+        status = await adapter.get_job_status("job_001")
+        
+        assert status == JobStatus.COMPLETED
+        job_queue.get_job_status.assert_called_once_with("job_001")
+    
+    @pytest.mark.asyncio
+    async def test_cancel_job(self):
+        """Test job cancellation."""
+        job_queue = Mock(spec=JobQueue)
+        job_queue.cancel_job = AsyncMock(return_value=True)
+        event_bus = Mock(spec=EventBus)
+        
+        adapter = JobQueueAdapter(job_queue, event_bus)
+        
+        result = await adapter.cancel_job("job_001")
+        
+        assert result is True
+        job_queue.cancel_job.assert_called_once_with("job_001")
+    
+    @pytest.mark.asyncio
+    async def test_get_all_jobs_status(self):
+        """Test getting all jobs status."""
+        job_queue = Mock(spec=JobQueue)
+        job_queue.get_all_jobs_status = AsyncMock(return_value={
+            "job_001": JobStatus.COMPLETED,
+            "job_002": JobStatus.PENDING
+        })
+        event_bus = Mock(spec=EventBus)
+        
+        adapter = JobQueueAdapter(job_queue, event_bus)
+        
+        statuses = await adapter.get_all_jobs_status("run_001")
+        
+        assert statuses == {
+            "job_001": JobStatus.COMPLETED,
+            "job_002": JobStatus.PENDING
+        }
+        job_queue.get_all_jobs_status.assert_called_once_with("run_001")
+
+
+class TestCreateEngineQueueIntegration:
+    """Test factory function."""
+    
+    @pytest.mark.asyncio
+    async def test_create_integration(self):
+        """Test factory function creates adapter."""
+        with patch('cine_mate.engine.queue_integration.JobQueue') as mock_queue, \
+             patch('cine_mate.engine.queue_integration.EventBus') as mock_bus:
+            
+            mock_queue_instance = AsyncMock()
+            mock_queue.return_value = mock_queue_instance
+            
+            mock_bus_instance = AsyncMock()
+            mock_bus.return_value = mock_bus_instance
+            
+            adapter = await create_engine_queue_integration("redis://localhost:6379")
+            
+            assert isinstance(adapter, JobQueueAdapter)
+            mock_queue.assert_called_once_with(redis_url="redis://localhost:6379")
+            mock_bus.assert_called_once_with(redis_url="redis://localhost:6379")
+            mock_queue_instance.connect.assert_called_once()
+            mock_bus_instance.connect.assert_called_once()


### PR DESCRIPTION
## 🎯 Purpose

Decouple Engine/Orchestrator from JobQueue implementation by introducing an adapter layer.

**Problem**: Direct coupling between Engine and JobQueue makes maintenance difficult and testing hard.

**Solution**: JobQueueAdapter provides a clean abstraction layer with event-driven callbacks.

## 🔧 Resources

### Architecture

```
Orchestrator → JobQueueAdapter → JobQueue → Worker
     ↓                              ↓
FSM callbacks ← EventBus ← Event publishing
```

### Changes

- **cine_mate/engine/queue_integration.py** (5.4KB)
  - JobQueueAdapter class
  - Event handler setup (node_completed, node_failed)
  - Callback registration
  - Factory function

- **cine_mate/engine/__init__.py**
  - Export JobQueueAdapter and factory function

- **tests/unit/engine/test_queue_integration.py** (7.7KB)
  - 12 unit tests
  - 100% pass rate

### Test Results

```
pytest tests/unit/engine/test_queue_integration.py -v
=================== 12 passed, 2 warnings ====================
```

## ✅ Expected Results

### Acceptance Criteria (Issue #29 Part 1/3)

- [x] JobQueue-Engine integration layer created
- [x] Event-driven callback mechanism implemented
- [x] Unit tests pass (12/12)
- [x] Decoupling achieved

### Related Issues

- Part 1/3: JobQueue Integration (this PR)
- Part 2/3: EventBus Complete Implementation (pending)
- Part 3/3: Agents Dependency Injection (pending)

---

**Closes**: #29 (Part 1/3)
**Sprint**: 3 Day 1
**Reviewer**: @lamwimham (PM)
