### PR TITLE
refactor(agents)[P0]: Fix dependency injection priority (Issue #29 Part 3/3)

### DIFF
--- a/cine_mate/agents/director_agent.py
+++ b/cine_mate/agents/director_agent.py
@@ -89,11 +89,11 @@ class DirectorAgent(ReActAgent):
         use_mock: bool = False,
         model=None  # Dependency injection for model
     ):
-        # 1. Setup Model
-        if use_mock:
+        # 1. Setup Model (Priority: injected model > use_mock > default)
+        if model is not None:
+            pass  # Use injected model (highest priority)
+        elif use_mock:
             model = MockChatModel()
-        elif model is not None:
-            pass  # Use injected model
         else:
             # Real DashScope (Qwen) - Sprint 2: with API Key validation
             resolved_api_key = api_key or os.getenv("DASHSCOPE_API_KEY")

--- a/tests/unit/agents/test_director_agent_di.py
+++ b/tests/unit/agents/test_director_agent_di.py
@@ -20,23 +20,25 @@ from unittest.mock import Mock, AsyncMock, patch, MagicMock
 class TestMockChatModel:
     """Test MockChatModel for testing without API keys."""
 
-    def test_mock_model_returns_json_response(self):
+    @pytest.mark.asyncio
+    async def test_mock_model_returns_json_response(self):
         """MockChatModel returns JSON DAG plan."""
         from cine_mate.agents.director_agent import MockChatModel
 
         mock_model = MockChatModel()
-        response = mock_model()
+        response = await mock_model()
 
         assert response is not None
         assert hasattr(response, 'content')
         assert len(response.content) > 0
 
-    def test_mock_response_contains_nodes(self):
+    @pytest.mark.asyncio
+    async def test_mock_response_contains_nodes(self):
         """Mock response contains DAG nodes."""
         from cine_mate.agents.director_agent import MockChatModel
 
         mock_model = MockChatModel()
-        response = mock_model()
+        response = await mock_model()
 
         text = response.content[0]["text"]
         data = json.loads(text)
@@ -44,12 +46,13 @@ class TestMockChatModel:
         assert "nodes" in data
         assert len(data["nodes"]) == 3  # script, image, video
 
-    def test_mock_nodes_have_correct_types(self):
+    @pytest.mark.asyncio
+    async def test_mock_nodes_have_correct_types(self):
         """Mock nodes have correct types."""
         from cine_mate.agents.director_agent import MockChatModel
 
         mock_model = MockChatModel()
-        response = mock_model()
+        response = await mock_model()
 
         text = response.content[0]["text"]
         data = json.loads(text)
@@ -153,7 +156,8 @@ class TestDirectorAgentDependencyInjection:
 
         # Case 1: Injected model takes priority over use_mock
         agent1 = DirectorAgent(model=custom_model, use_mock=True, engine_tools=None)
-        assert agent1.model == custom_model  # Not MockChatModel
+        # Injected model should be used (not MockChatModel instance)
+        assert agent1.model is custom_model
 
         # Case 2: use_mock when no model injected
         agent2 = DirectorAgent(use_mock=True, engine_tools=None)


### PR DESCRIPTION
## 🎯 Purpose

Fix Agents dependency injection to enable better testing and decoupling.

**Problem**: Dependency injection priority was incorrect - use_mock would override injected model.

**Solution**: Fix priority order: injected model > use_mock > default

## 🔧 Resources

### Changes

- **cine_mate/agents/director_agent.py**
  - Fix model injection priority
  - Priority: injected > use_mock > default

- **tests/unit/agents/test_director_agent_di.py**
  - Fix async tests (add @pytest.mark.asyncio)
  - Install agentscope dependency

### Test Results

```
pytest tests/unit/agents/test_director_agent_di.py -v
======================== 22 passed, 1 warning =========================
```

### Coverage

- Agents module: 26% (improved from 21%)
- Target: 75% (Sprint 3)

## ✅ Expected Results

### Acceptance Criteria (Issue #29 Part 3/3)

- [x] Dependency injection priority fixed
- [x] All tests passing (22/22)
- [x] Mock mode works correctly
- [x] Injected model takes priority

### Related Issues

- Part 1/3: JobQueue Integration ✅ PR #30
- Part 2/3: EventBus Complete ✅ (already in main)
- Part 3/3: Agents Dependency Injection (this PR)

---

**Closes**: #29 (Part 3/3)
**Sprint**: 3 Day 1
**Reviewer**: @lamwimham (PM)
