### PR TITLE
feat: SkillStore + SkillIndexer + MVP CLI (Sprint 3 Day 2)

### DIFF
--- a/cine_mate/skills/__init__.py
+++ b/cine_mate/skills/__init__.py
@@ -1,1 +1,18 @@
-# Empty init
+"""CineMate Skill System — progressive disclosure + auto-generation."""
+
+from cine_mate.skills.models import (
+    SkillMetadata, SkillIndexEntry, SkillFullContent,
+    SkillCategory, SkillStatus,
+)
+from cine_mate.skills.skill_store import SkillStore
+from cine_mate.skills.skill_indexer import SkillIndexer
+
+__all__ = [
+    "SkillMetadata",
+    "SkillIndexEntry",
+    "SkillFullContent",
+    "SkillCategory",
+    "SkillStatus",
+    "SkillStore",
+    "SkillIndexer",
+]

--- a/cine_mate/skills/data/style-cyberpunk/SKILL.md
+++ b/cine_mate/skills/data/style-cyberpunk/SKILL.md
@@ -1,0 +1,33 @@
+---
+name: style-cyberpunk
+description: Cyberpunk visual style — neon lights, rain-soaked streets, high contrast, synthwave color palette
+category: style
+version: 1.0.0
+author: cinemate
+scenario: style-transfer
+tags: [neon, dark, sci-fi, synthwave]
+---
+
+# Cyberpunk Style Guide
+
+## Visual Characteristics
+- **Color palette**: Cyan (#00FFFF), magenta (#FF00FF), deep blue (#0A0A2E), neon pink
+- **Lighting**: High contrast, volumetric fog, lens flares, neon glow
+- **Environment**: Rain-soaked streets, holographic billboards, dense urban architecture
+- **Mood**: Dystopian, high-tech low-life, atmospheric
+
+## Prompt Template
+```
+{subject}, cyberpunk style, neon lights, rain, dark city background,
+cyan and magenta lighting, volumetric fog, cinematic, 4k, --ar 16:9
+```
+
+## Model-Specific Tips
+- **Kling I2V**: Add "slow camera pan" for best motion results
+- **Flux T2I**: Use `--v 2` for enhanced neon rendering
+- **Runway Gen-3**: Set motion bucket to 7 for subtle atmospheric movement
+
+## Avoid
+- Over-exposed scenes (neon should glow, not bleach)
+- Generic "futuristic" without specific cyberpunk markers
+- Daylight scenes (cyberpunk is primarily nocturnal)

--- a/cine_mate/skills/data/workflow-short-ad/SKILL.md
+++ b/cine_mate/skills/data/workflow-short-ad/SKILL.md
@@ -1,0 +1,43 @@
+---
+name: workflow-short-ad
+description: 15-second product ad template — hook → demo → CTA, optimized for social media
+category: workflow
+version: 1.0.0
+author: cinemate
+scenario: product-video
+tags: [advertising, social-media, short-form]
+---
+
+# Short Ad Workflow Template
+
+## Structure (15 seconds)
+
+| Phase | Duration | Purpose | Node Type |
+|-------|----------|---------|-----------|
+| Hook | 0-3s | Grab attention | text_to_video |
+| Demo | 3-10s | Show product | image_to_video |
+| CTA | 10-15s | Call to action | text_to_video |
+
+## DAG Template
+```json
+{
+  "nodes": [
+    {"id": "hook_script", "type": "script_generation", "params": {"duration": 3, "tone": "energetic"}},
+    {"id": "hook_video", "type": "text_to_video", "depends_on": ["hook_script"]},
+    {"id": "product_shot", "type": "image_generation", "params": {"style": "clean_product"}},
+    {"id": "demo_video", "type": "image_to_video", "depends_on": ["product_shot"], "params": {"motion": "pan"}},
+    {"id": "cta_script", "type": "script_generation", "params": {"duration": 5, "tone": "urgent"}},
+    {"id": "cta_video", "type": "text_to_video", "depends_on": ["cta_script"]},
+    {"id": "compose", "type": "video_compose", "depends_on": ["hook_video", "demo_video", "cta_video"]}
+  ]
+}
+```
+
+## Model Recommendations
+- **Budget**: qwen-turbo (script) + wanx (image) + kling-v1 (video)
+- **Quality**: qwen-max (script) + flux-pro (image) + kling-v1.6-pro (video)
+
+## Common Pitfalls
+- Hook too long (>3s loses retention)
+- CTA without clear action verb
+- Demo phase needs at least one product close-up

--- a/cine_mate/skills/models.py
+++ b/cine_mate/skills/models.py
@@ -1,0 +1,75 @@
+"""
+CineMate Skill System Data Models (Pydantic V2)
+Skills provide progressive disclosure for the DirectorAgent — decision-layer
+patterns (style strategies, workflow templates, error recovery), not
+infrastructure code.
+"""
+
+from pydantic import BaseModel, Field, field_validator
+from typing import Optional, Dict, Any, List
+from datetime import datetime
+from enum import Enum
+
+
+class SkillCategory(str, Enum):
+    STYLE = "style"              # Style strategy (e.g., cyberpunk, wong-kar-wai)
+    WORKFLOW = "workflow"        # Workflow template (e.g., short-ad, product-review)
+    ERROR_RECOVERY = "error"     # Error recovery patterns (e.g., kling-face-distortion)
+    QUALITY = "quality"          # Quality gating and evaluation
+
+
+class SkillStatus(str, Enum):
+    ENABLED = "enabled"
+    DISABLED = "disabled"
+
+
+class SkillMetadata(BaseModel):
+    """
+    Metadata extracted from SKILL.md YAML frontmatter.
+    Mirrors the SQLite skills table schema.
+    """
+    name: str                    # Unique skill identifier (e.g., "style-cyberpunk")
+    description: str             # Short description shown in progressive disclosure index
+    category: SkillCategory
+    version: str = "1.0.0"
+    author: str = "cinemate"
+    
+    # Filtering
+    agent: Optional[str] = None  # Target agent (e.g., "director", "editor") — None = all
+    scenario: Optional[str] = None  # Trigger scenario (e.g., "video-generation", "style-transfer")
+    tags: List[str] = Field(default_factory=list)
+    
+    # Provenance (for Hermes auto-generation mechanism)
+    auto_generated: bool = False           # True if created by SkillReviewer
+    source_run_id: Optional[str] = None    # Link to the PipelineRun that triggered this skill
+    source_error: Optional[str] = None     # Error pattern that triggered auto-generation
+    
+    # Internal
+    status: SkillStatus = SkillStatus.ENABLED
+    content_hash: Optional[str] = None  # SHA256 of SKILL.md content for change detection
+    created_at: datetime = Field(default_factory=datetime.now)
+    updated_at: datetime = Field(default_factory=datetime.now)
+
+
+class SkillIndexEntry(BaseModel):
+    """
+    Lightweight index entry for progressive disclosure.
+    Only name + description injected into DirectorAgent system prompt.
+    """
+    name: str
+    description: str
+    category: SkillCategory
+    tags: List[str] = Field(default_factory=list)
+    
+    def format_for_prompt(self) -> str:
+        """Format as a single line for the available skills index."""
+        tag_str = f" [{', '.join(self.tags)}]" if self.tags else ""
+        return f"- {self.name}: {self.description}{tag_str}"
+
+
+class SkillFullContent(BaseModel):
+    """
+    Complete skill content loaded on-demand via skill() tool.
+    """
+    metadata: SkillMetadata
+    content: str  # Full SKILL.md markdown body (without frontmatter)

--- a/cine_mate/skills/skill_indexer.py
+++ b/cine_mate/skills/skill_indexer.py
@@ -1,0 +1,145 @@
+"""
+CineMate SkillIndexer — Progressive Disclosure Index Builder
+
+Scans the skills directory, builds an in-memory index, and provides
+the `available()` method for the DirectorAgent's system prompt injection.
+
+Progressive Disclosure Pattern (from OpenCode):
+1. System prompt receives ONLY the skill index (name + description)
+2. Full SKILL.md content loads on-demand via the skill() tool
+3. This prevents context window overflow from loading all skills at once
+
+Auto-Generation Support (from Hermes):
+- Index includes `auto_generated` flag for provenance tracking
+- Skills auto-created by SkillReviewer are indexed alongside hand-written ones
+"""
+
+import json
+import aiosqlite
+from pathlib import Path
+from typing import Optional, List
+from datetime import datetime
+
+from cine_mate.skills.models import (
+    SkillMetadata, SkillCategory, SkillIndexEntry, SkillStatus
+)
+from cine_mate.skills.skill_store import SkillStore
+
+
+class SkillIndexer:
+    """
+    Scans skill directory, builds and caches an index for progressive disclosure.
+    
+    The index is the lightweight view injected into the DirectorAgent's system prompt.
+    Full content is loaded on-demand via SkillStore.read().
+    """
+    
+    def __init__(self, store: SkillStore):
+        self.store = store
+        self._index: Optional[List[SkillIndexEntry]] = None
+        self._last_scan: Optional[datetime] = None
+    
+    async def scan(self) -> List[SkillIndexEntry]:
+        """
+        Scan the skills directory and rebuild the index from SQLite metadata.
+        
+        Returns:
+            List of SkillIndexEntry (lightweight, for system prompt injection)
+        """
+        all_skills = await self.store.list_all(status=SkillStatus.ENABLED)
+        
+        self._index = [
+            SkillIndexEntry(
+                name=skill.name,
+                description=skill.description,
+                category=skill.category,
+                tags=skill.tags,
+            )
+            for skill in all_skills
+        ]
+        self._last_scan = datetime.now()
+        return self._index
+    
+    async def available(
+        self,
+        agent: Optional[str] = None,
+        scenario: Optional[str] = None,
+        category: Optional[SkillCategory] = None,
+    ) -> List[SkillIndexEntry]:
+        """
+        Return available skills, optionally filtered.
+        
+        This is the primary method called during system prompt construction.
+        Returns only enabled skills matching the filter criteria.
+        
+        Args:
+            agent: Filter by target agent (e.g., "director") — None = all
+            scenario: Filter by trigger scenario — None = all
+            category: Filter by skill category — None = all
+        
+        Returns:
+            Filtered list of SkillIndexEntry for system prompt injection
+        """
+        # Lazy scan if not yet scanned
+        if self._index is None:
+            await self.scan()
+        
+        results = self._index
+        
+        if category:
+            results = [s for s in results if s.category == category]
+        
+        # For agent/scenario filtering, need full metadata from SQLite
+        if agent or scenario:
+            all_meta = await self.store.list_all(status=SkillStatus.ENABLED)
+            filtered_names = set()
+            for skill in all_meta:
+                if agent and skill.agent and skill.agent != agent:
+                    continue
+                if scenario and skill.scenario and skill.scenario != scenario:
+                    continue
+                filtered_names.add(skill.name)
+            results = [s for s in results if s.name in filtered_names]
+        
+        return results
+    
+    def format_for_prompt(self, entries: Optional[List[SkillIndexEntry]] = None) -> str:
+        """
+        Format skill index for injection into DirectorAgent system prompt.
+        
+        Output format (OpenCode pattern):
+        ## Available Skills
+        - style-cyberpunk: Cyberpunk visual style with neon accents
+        - workflow-short-ad: 15-second product ad template
+        
+        Args:
+            entries: Skill entries to format (uses full index if None)
+        """
+        if entries is None:
+            entries = self._index or []
+        
+        if not entries:
+            return "## Available Skills\n(None available)"
+        
+        lines = ["## Available Skills"]
+        for entry in entries:
+            lines.append(entry.format_for_prompt())
+        return "\n".join(lines)
+    
+    async def get_skill_names(self) -> List[str]:
+        """Return list of all enabled skill names."""
+        if self._index is None:
+            await self.scan()
+        return [s.name for s in self._index]
+    
+    def is_stale(self, max_age_seconds: float = 60.0) -> bool:
+        """Check if the index needs rescanning."""
+        if self._last_scan is None:
+            return True
+        return (datetime.now() - self._last_scan).total_seconds() > max_age_seconds
+    
+    async def refresh_if_stale(self, max_age_seconds: float = 60.0) -> List[SkillIndexEntry]:
+        """Refresh the index if it's stale, otherwise return cached."""
+        if self.is_stale(max_age_seconds):
+            return await self.scan()
+        return self._index or []

--- a/cine_mate/skills/skill_store.py
+++ b/cine_mate/skills/skill_store.py
@@ -1,0 +1,400 @@
+"""
+CineMate SkillStore — Local File System + SQLite Metadata Store
+Supports CRUD operations, YAML frontmatter validation, and auto-generation
+provenance tracking (for SkillReviewer).
+
+Storage layout:
+    skills/
+    ├── skills.db              # SQLite metadata
+    ├── data/
+    │   ├── style-cyberpunk/
+    │   │   └── SKILL.md       # YAML frontmatter + markdown body
+    │   └── workflow-short-ad/
+    │       └── SKILL.md
+"""
+
+import aiosqlite
+import hashlib
+import yaml
+from pathlib import Path
+from typing import Optional, List
+from datetime import datetime
+
+from cine_mate.skills.models import (
+    SkillMetadata, SkillStatus, SkillCategory, SkillFullContent
+)
+
+
+# --- SQL DDL ---
+
+SCHEMA_SKILLS = """
+CREATE TABLE IF NOT EXISTS skills (
+    name TEXT PRIMARY KEY,
+    description TEXT NOT NULL,
+    category TEXT NOT NULL,
+    version TEXT DEFAULT '1.0.0',
+    author TEXT DEFAULT 'cinemate',
+    
+    -- Filtering
+    agent TEXT,
+    scenario TEXT,
+    tags TEXT,  -- JSON array
+    
+    -- Provenance (auto-generation)
+    auto_generated INTEGER DEFAULT 0,
+    source_run_id TEXT,
+    source_error TEXT,
+    
+    -- Internal
+    status TEXT DEFAULT 'enabled',
+    content_hash TEXT,
+    created_at DATETIME DEFAULT (strftime('%Y-%m-%d %H:%M:%f', 'now')),
+    updated_at DATETIME DEFAULT (strftime('%Y-%m-%d %H:%M:%f', 'now'))
+);
+
+CREATE INDEX IF NOT EXISTS idx_skills_category ON skills(category);
+CREATE INDEX IF NOT EXISTS idx_skills_status ON skills(status);
+CREATE INDEX IF NOT EXISTS idx_skills_agent ON skills(agent);
+CREATE INDEX IF NOT EXISTS idx_skills_scenario ON skills(scenario);
+CREATE INDEX IF NOT EXISTS idx_skills_auto_generated ON skills(auto_generated);
+"""
+
+
+def _parse_frontmatter(content: str) -> tuple[dict, str]:
+    """
+    Parse YAML frontmatter from SKILL.md content.
+    Returns (frontmatter_dict, body_string).
+    """
+    if not content.startswith("---"):
+        return {}, content
+    
+    parts = content.split("---", 2)
+    if len(parts) < 3:
+        return {}, content
+    
+    fm = yaml.safe_load(parts[1]) or {}
+    body = parts[2].strip()
+    return fm, body
+
+
+def _build_frontmatter(meta: SkillMetadata) -> str:
+    """Build YAML frontmatter from SkillMetadata."""
+    fm = {
+        "name": meta.name,
+        "description": meta.description,
+        "category": meta.category.value,
+        "version": meta.version,
+        "author": meta.author,
+    }
+    if meta.agent:
+        fm["agent"] = meta.agent
+    if meta.scenario:
+        fm["scenario"] = meta.scenario
+    if meta.tags:
+        fm["tags"] = meta.tags
+    if meta.auto_generated:
+        fm["auto_generated"] = True
+    if meta.source_run_id:
+        fm["source_run_id"] = meta.source_run_id
+    if meta.source_error:
+        fm["source_error"] = meta.source_error
+    return yaml.dump(fm, default_flow_style=False, allow_unicode=True)
+
+
+def _compute_hash(content: str) -> str:
+    """SHA256 hash of SKILL.md content for change detection."""
+    return hashlib.sha256(content.encode("utf-8")).hexdigest()[:16]
+
+
+class SkillStore:
+    """
+    Local File System + SQLite Store for CineMate Skills.
+    
+    Supports:
+    - CRUD operations on skills
+    - YAML frontmatter validation
+    - Auto-generation provenance (for SkillReviewer)
+    - Content hash change detection
+    """
+    
+    def __init__(self, skills_dir: Path):
+        self.skills_dir = skills_dir
+        self.data_dir = skills_dir / "data"
+        self.db_path = skills_dir / "skills.db"
+    
+    async def init(self):
+        """Initialize database schema and ensure directories exist."""
+        self.data_dir.mkdir(parents=True, exist_ok=True)
+        
+        async with aiosqlite.connect(self.db_path) as db:
+            await db.execute("PRAGMA journal_mode=WAL;")
+            await db.execute("PRAGMA foreign_keys=ON;")
+            for stmt in SCHEMA_SKILLS.split(";"):
+                stmt = stmt.strip()
+                if stmt:
+                    await db.execute(stmt)
+            await db.commit()
+    
+    def _skill_dir(self, name: str) -> Path:
+        return self.data_dir / name
+    
+    def _skill_file(self, name: str) -> Path:
+        return self._skill_dir(name) / "SKILL.md"
+    
+    # --- CRUD Operations ---
+    
+    async def create(self, name: str, content: str, metadata: Optional[SkillMetadata] = None) -> SkillMetadata:
+        """
+        Create a new skill.
+        
+        Args:
+            name: Unique skill identifier
+            content: Full SKILL.md content (with or without frontmatter)
+            metadata: Optional metadata override (extracted from frontmatter if not provided)
+        
+        Returns:
+            SkillMetadata for the created skill
+        """
+        # Parse frontmatter if present
+        fm, body = _parse_frontmatter(content)
+        
+        # Build metadata from frontmatter or override
+        if metadata:
+            meta = metadata
+        else:
+            meta = SkillMetadata(
+                name=fm.get("name", name),
+                description=fm.get("description", ""),
+                category=SkillCategory(fm.get("category", "style")),
+                version=fm.get("version", "1.0.0"),
+                author=fm.get("author", "cinemate"),
+                agent=fm.get("agent"),
+                scenario=fm.get("scenario"),
+                tags=fm.get("tags", []),
+                auto_generated=fm.get("auto_generated", False),
+                source_run_id=fm.get("source_run_id"),
+                source_error=fm.get("source_error"),
+            )
+        
+        # Ensure name matches
+        meta.name = name
+        
+        # Build canonical content (frontmatter + body)
+        fm_yaml = _build_frontmatter(meta)
+        canonical_content = f"---\n{fm_yaml}---\n\n{body}" if body else f"---\n{fm_yaml}---\n"
+        
+        # Compute hash
+        meta.content_hash = _compute_hash(canonical_content)
+        meta.updated_at = datetime.now()
+        
+        # Write to filesystem
+        skill_dir = self._skill_dir(name)
+        skill_dir.mkdir(parents=True, exist_ok=True)
+        self._skill_file(name).write_text(canonical_content, encoding="utf-8")
+        
+        # Write to SQLite
+        import json
+        async with aiosqlite.connect(self.db_path) as db:
+            await db.execute(
+                """
+                INSERT INTO skills 
+                (name, description, category, version, author, agent, scenario, tags,
+                 auto_generated, source_run_id, source_error, status, content_hash, updated_at)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    meta.name, meta.description, meta.category.value,
+                    meta.version, meta.author, meta.agent, meta.scenario,
+                    json.dumps(meta.tags),
+                    int(meta.auto_generated), meta.source_run_id, meta.source_error,
+                    meta.status.value, meta.content_hash,
+                    meta.updated_at.isoformat()
+                )
+            )
+            await db.commit()
+        
+        return meta
+    
+    async def read(self, name: str) -> Optional[SkillFullContent]:
+        """
+        Read a skill's full content (progressive disclosure: full load).
+        
+        Returns:
+            SkillFullContent with metadata + body, or None if not found
+        """
+        # Read from filesystem
+        skill_file = self._skill_file(name)
+        if not skill_file.exists():
+            return None
+        
+        raw_content = skill_file.read_text(encoding="utf-8")
+        fm, body = _parse_frontmatter(raw_content)
+        
+        # Read metadata from SQLite for consistency
+        import json
+        async with aiosqlite.connect(self.db_path) as db:
+            db.row_factory = aiosqlite.Row
+            async with db.execute("SELECT * FROM skills WHERE name = ?", (name,)) as cursor:
+                row = await cursor.fetchone()
+        
+        if row:
+            meta = SkillMetadata(
+                name=row["name"],
+                description=row["description"],
+                category=SkillCategory(row["category"]),
+                version=row["version"],
+                author=row["author"],
+                agent=row["agent"],
+                scenario=row["scenario"],
+                tags=json.loads(row["tags"]) if row["tags"] else [],
+                auto_generated=bool(row["auto_generated"]),
+                source_run_id=row["source_run_id"],
+                source_error=row["source_error"],
+                status=SkillStatus(row["status"]),
+                content_hash=row["content_hash"],
+                created_at=datetime.fromisoformat(row["created_at"]),
+                updated_at=datetime.fromisoformat(row["updated_at"]),
+            )
+        else:
+            # Fallback: construct from frontmatter only
+            meta = SkillMetadata(
+                name=fm.get("name", name),
+                description=fm.get("description", ""),
+                category=SkillCategory(fm.get("category", "style")),
+                version=fm.get("version", "1.0.0"),
+                author=fm.get("author", "cinemate"),
+                agent=fm.get("agent"),
+                scenario=fm.get("scenario"),
+                tags=fm.get("tags", []),
+                auto_generated=fm.get("auto_generated", False),
+                source_run_id=fm.get("source_run_id"),
+                source_error=fm.get("source_error"),
+                content_hash=_compute_hash(raw_content),
+            )
+        
+        return SkillFullContent(metadata=meta, content=body)
+    
+    async def update(self, name: str, content: str) -> Optional[SkillMetadata]:
+        """
+        Update an existing skill's content.
+        
+        Validates that the skill exists, updates filesystem + SQLite.
+        Returns updated metadata or None if skill not found.
+        """
+        skill_file = self._skill_file(name)
+        if not skill_file.exists():
+            return None
+        
+        fm, body = _parse_frontmatter(content)
+        
+        # Read existing metadata
+        existing = await self.read(name)
+        if not existing:
+            return None
+        
+        meta = existing.metadata
+        
+        # Update from new frontmatter if provided
+        if "description" in fm:
+            meta.description = fm["description"]
+        if "category" in fm:
+            meta.category = SkillCategory(fm["category"])
+        if "version" in fm:
+            meta.version = fm["version"]
+        if "tags" in fm:
+            meta.tags = fm["tags"]
+        if "scenario" in fm:
+            meta.scenario = fm["scenario"]
+        
+        # Update hash and timestamp
+        canonical_content = f"---\n{_build_frontmatter(meta)}---\n\n{body}" if body else f"---\n{_build_frontmatter(meta)}---\n"
+        meta.content_hash = _compute_hash(canonical_content)
+        meta.updated_at = datetime.now()
+        
+        # Write filesystem
+        skill_file.write_text(canonical_content, encoding="utf-8")
+        
+        # Write SQLite
+        import json
+        async with aiosqlite.connect(self.db_path) as db:
+            await db.execute(
+                """
+                UPDATE skills SET 
+                    description=?, category=?, version=?, tags=?, scenario=?,
+                    content_hash=?, updated_at=?
+                WHERE name=?
+                """,
+                (
+                    meta.description, meta.category.value, meta.version,
+                    json.dumps(meta.tags), meta.scenario,
+                    meta.content_hash, meta.updated_at.isoformat(),
+                    meta.name
+                )
+            )
+            await db.commit()
+        
+        return meta
+    
+    async def delete(self, name: str) -> bool:
+        """
+        Delete a skill (filesystem + SQLite).
+        Returns True if deleted, False if not found.
+        """
+        skill_file = self._skill_file(name)
+        skill_dir = self._skill_dir(name)
+        
+        if not skill_file.exists():
+            return False
+        
+        # Remove filesystem
+        skill_file.unlink()
+        if skill_dir.exists() and not any(skill_dir.iterdir()):
+            skill_dir.rmdir()
+        
+        # Remove from SQLite
+        async with aiosqlite.connect(self.db_path) as db:
+            await db.execute("DELETE FROM skills WHERE name = ?", (name,))
+            await db.commit()
+        
+        return True
+    
+    # --- Query Operations ---
+    
+    async def list_all(self, status: Optional[SkillStatus] = None) -> List[SkillMetadata]:
+        """List all skills, optionally filtered by status."""
+        import json
+        query = "SELECT * FROM skills"
+        params = []
+        if status:
+            query += " WHERE status = ?"
+            params.append(status.value)
+        
+        async with aiosqlite.connect(self.db_path) as db:
+            db.row_factory = aiosqlite.Row
+            async with db.execute(query, params) as cursor:
+                rows = await cursor.fetchall()
+        
+        return [
+            SkillMetadata(
+                name=row["name"],
+                description=row["description"],
+                category=SkillCategory(row["category"]),
+                version=row["version"],
+                author=row["author"],
+                agent=row["agent"],
+                scenario=row["scenario"],
+                tags=json.loads(row["tags"]) if row["tags"] else [],
+                auto_generated=bool(row["auto_generated"]),
+                source_run_id=row["source_run_id"],
+                source_error=row["source_error"],
+                status=SkillStatus(row["status"]),
+                content_hash=row["content_hash"],
+                created_at=datetime.fromisoformat(row["created_at"]),
+                updated_at=datetime.fromisoformat(row["updated_at"]),
+            )
+            for row in rows
+        ]
+    
+    async def exists(self, name: str) -> bool:
+        """Check if a skill exists."""
+        return self._skill_file(name).exists()

--- a/tests/unit/skills/test_skill_store.py
+++ b/tests/unit/skills/test_skill_store.py
@@ -1,0 +1,514 @@
+"""
+Tests for CineMate SkillStore and SkillIndexer.
+Covers CRUD operations, frontmatter validation, progressive disclosure indexing,
+and auto-generation provenance tracking.
+"""
+
+import pytest
+import tempfile
+from pathlib import Path
+
+from cine_mate.skills.skill_store import SkillStore
+from cine_mate.skills.skill_indexer import SkillIndexer
+from cine_mate.skills.models import (
+    SkillMetadata, SkillCategory, SkillStatus, SkillIndexEntry
+)
+
+
+# =============================================================================
+# Fixtures
+# =============================================================================
+
+@pytest.fixture
+async def skills_dir():
+    """Provide a temporary skills directory."""
+    with tempfile.TemporaryDirectory() as tmp:
+        yield Path(tmp)
+
+
+@pytest.fixture
+async def store(skills_dir):
+    """Provide a fresh SkillStore instance."""
+    s = SkillStore(skills_dir)
+    await s.init()
+    yield s
+
+
+@pytest.fixture
+async def indexer(store):
+    """Provide a SkillIndexer backed by the store."""
+    return SkillIndexer(store)
+
+
+@pytest.fixture
+async def populated_store(store):
+    """SkillStore with pre-installed test skills."""
+    await store.create(
+        name="style-cyberpunk",
+        content="""---
+name: style-cyberpunk
+description: Cyberpunk visual style with neon accents
+category: style
+tags: [neon, sci-fi]
+---
+
+Cyberpunk style guide content here.
+""",
+        metadata=SkillMetadata(
+            name="style-cyberpunk",
+            description="Cyberpunk visual style with neon accents",
+            category=SkillCategory.STYLE,
+            tags=["neon", "sci-fi"],
+            scenario="style-transfer",
+        )
+    )
+    
+    await store.create(
+        name="workflow-short-ad",
+        content="""---
+name: workflow-short-ad
+description: 15-second product ad template
+category: workflow
+tags: [advertising]
+---
+
+Short ad workflow content here.
+""",
+        metadata=SkillMetadata(
+            name="workflow-short-ad",
+            description="15-second product ad template",
+            category=SkillCategory.WORKFLOW,
+            tags=["advertising"],
+            scenario="product-video",
+            agent="director",
+        )
+    )
+    
+    await store.create(
+        name="error-kling-faces",
+        content="""---
+name: error-kling-faces
+description: Recovery pattern for Kling face distortion
+category: error
+auto_generated: true
+source_run_id: run_042
+source_error: "face_distortion_v2"
+---
+
+Error recovery pattern for face distortion.
+""",
+        metadata=SkillMetadata(
+            name="error-kling-faces",
+            description="Recovery pattern for Kling face distortion",
+            category=SkillCategory.ERROR_RECOVERY,
+            auto_generated=True,
+            source_run_id="run_042",
+            source_error="face_distortion_v2",
+        )
+    )
+    
+    yield store
+
+
+# =============================================================================
+# SkillStore Tests
+# =============================================================================
+
+class TestSkillStoreCreate:
+    """Test skill creation with frontmatter and metadata."""
+    
+    @pytest.mark.asyncio
+    async def test_create_with_frontmatter(self, store):
+        """Create skill from content with YAML frontmatter."""
+        content = """---
+name: style-retro
+description: Retro 80s visual style
+category: style
+version: 2.0.0
+---
+
+Retro style guide content.
+"""
+        meta = await store.create("style-retro", content)
+        
+        assert meta.name == "style-retro"
+        assert meta.description == "Retro 80s visual style"
+        assert meta.category == SkillCategory.STYLE
+        assert meta.version == "2.0.0"
+        assert meta.content_hash is not None
+    
+    @pytest.mark.asyncio
+    async def test_create_with_metadata_override(self, store):
+        """Create skill with explicit metadata override."""
+        meta = await store.create(
+            name="style-minimal",
+            content="Minimal style content.",
+            metadata=SkillMetadata(
+                name="style-minimal",
+                description="Minimal clean style",
+                category=SkillCategory.STYLE,
+                tags=["clean", "minimal"],
+            )
+        )
+        
+        assert meta.description == "Minimal clean style"
+        assert meta.tags == ["clean", "minimal"]
+    
+    @pytest.mark.asyncio
+    async def test_create_writes_filesystem(self, store):
+        """Create skill writes SKILL.md to data directory."""
+        await store.create(
+            name="test-skill",
+            content="Test content.",
+            metadata=SkillMetadata(
+                name="test-skill",
+                description="Test",
+                category=SkillCategory.STYLE,
+            )
+        )
+        
+        skill_file = store._skill_file("test-skill")
+        assert skill_file.exists()
+        content = skill_file.read_text()
+        assert "---" in content  # Has frontmatter
+        assert "Test content." in content
+    
+    @pytest.mark.asyncio
+    async def test_create_writes_sqlite(self, store):
+        """Create skill writes metadata to SQLite."""
+        meta = await store.create(
+            name="test-skill",
+            content="Test content.",
+            metadata=SkillMetadata(
+                name="test-skill",
+                description="Test",
+                category=SkillCategory.STYLE,
+            )
+        )
+        
+        skills = await store.list_all()
+        assert any(s.name == "test-skill" for s in skills)
+    
+    @pytest.mark.asyncio
+    async def test_create_auto_generated_provenance(self, store):
+        """Create skill with auto-generation metadata (Hermes pattern)."""
+        meta = await store.create(
+            name="error-auto-recovered",
+            content="Auto-generated error recovery.",
+            metadata=SkillMetadata(
+                name="error-auto-recovered",
+                description="Auto-recovered error pattern",
+                category=SkillCategory.ERROR_RECOVERY,
+                auto_generated=True,
+                source_run_id="run_099",
+                source_error="timeout_kling_v1",
+            )
+        )
+        
+        assert meta.auto_generated is True
+        assert meta.source_run_id == "run_099"
+        assert meta.source_error == "timeout_kling_v1"
+    
+    @pytest.mark.asyncio
+    async def test_create_computes_content_hash(self, store):
+        """Create skill computes SHA256 hash for change detection."""
+        meta = await store.create(
+            name="hash-test",
+            content="Original content.",
+            metadata=SkillMetadata(
+                name="hash-test",
+                description="Hash test",
+                category=SkillCategory.STYLE,
+            )
+        )
+        
+        assert meta.content_hash is not None
+        assert len(meta.content_hash) == 16  # Truncated SHA256
+        
+        # Update content, hash should change
+        await store.update("hash-test", "Modified content.")
+        updated = await store.read("hash-test")
+        assert updated.metadata.content_hash != meta.content_hash
+
+
+class TestSkillStoreRead:
+    """Test skill reading with progressive disclosure."""
+    
+    @pytest.mark.asyncio
+    async def test_read_returns_full_content(self, populated_store):
+        """Read skill returns SkillFullContent with metadata + body."""
+        result = await populated_store.read("style-cyberpunk")
+        
+        assert result is not None
+        assert result.metadata.name == "style-cyberpunk"
+        assert "Cyberpunk style guide content here." in result.content
+    
+    @pytest.mark.asyncio
+    async def test_read_missing_skill_returns_none(self, store):
+        """Read non-existent skill returns None."""
+        result = await store.read("nonexistent-skill")
+        assert result is None
+    
+    @pytest.mark.asyncio
+    async def test_read_auto_generated_skill(self, populated_store):
+        """Read auto-generated skill preserves provenance."""
+        result = await populated_store.read("error-kling-faces")
+        
+        assert result.metadata.auto_generated is True
+        assert result.metadata.source_run_id == "run_042"
+        assert result.metadata.source_error == "face_distortion_v2"
+
+
+class TestSkillStoreUpdate:
+    """Test skill updates."""
+    
+    @pytest.mark.asyncio
+    async def test_update_existing_skill(self, populated_store):
+        """Update modifies content and metadata."""
+        result = await populated_store.update(
+            "style-cyberpunk",
+            """---
+name: style-cyberpunk
+description: Updated cyberpunk description
+category: style
+---
+
+Updated content body.
+"""
+        )
+        
+        assert result is not None
+        assert result.description == "Updated cyberpunk description"
+        
+        # Verify filesystem updated
+        full = await populated_store.read("style-cyberpunk")
+        assert "Updated content body." in full.content
+    
+    @pytest.mark.asyncio
+    async def test_update_missing_skill_returns_none(self, store):
+        """Update non-existent skill returns None."""
+        result = await store.update("nonexistent", "new content")
+        assert result is None
+
+
+class TestSkillStoreDelete:
+    """Test skill deletion."""
+    
+    @pytest.mark.asyncio
+    async def test_delete_existing_skill(self, populated_store):
+        """Delete removes filesystem + SQLite."""
+        result = await populated_store.delete("style-cyberpunk")
+        assert result is True
+        
+        # Filesystem removed
+        assert not populated_store._skill_file("style-cyberpunk").exists()
+        
+        # SQLite removed
+        skills = await populated_store.list_all()
+        assert not any(s.name == "style-cyberpunk" for s in skills)
+    
+    @pytest.mark.asyncio
+    async def test_delete_missing_skill_returns_false(self, store):
+        """Delete non-existent skill returns False."""
+        result = await store.delete("nonexistent")
+        assert result is False
+
+
+class TestSkillStoreList:
+    """Test skill listing and filtering."""
+    
+    @pytest.mark.asyncio
+    async def test_list_all_skills(self, populated_store):
+        """List returns all enabled skills."""
+        skills = await populated_store.list_all()
+        assert len(skills) == 3
+    
+    @pytest.mark.asyncio
+    async def test_list_filter_by_status(self, store):
+        """List can filter by status."""
+        await store.create(
+            name="active-skill",
+            content="Active.",
+            metadata=SkillMetadata(
+                name="active-skill",
+                description="Active",
+                category=SkillCategory.STYLE,
+                status=SkillStatus.ENABLED,
+            )
+        )
+        
+        enabled = await store.list_all(status=SkillStatus.ENABLED)
+        assert len(enabled) == 1
+        assert enabled[0].name == "active-skill"
+    
+    @pytest.mark.asyncio
+    async def test_exists(self, populated_store):
+        """Exists check works correctly."""
+        assert await populated_store.exists("style-cyberpunk") is True
+        assert await populated_store.exists("nonexistent") is False
+
+
+# =============================================================================
+# SkillIndexer Tests
+# =============================================================================
+
+class TestSkillIndexerScan:
+    """Test index building and caching."""
+    
+    @pytest.mark.asyncio
+    async def test_scan_builds_index(self, populated_store, indexer):
+        """Scan reads all enabled skills and builds index."""
+        entries = await indexer.scan()
+        
+        assert len(entries) == 3
+        names = {e.name for e in entries}
+        assert "style-cyberpunk" in names
+        assert "workflow-short-ad" in names
+        assert "error-kling-faces" in names
+    
+    @pytest.mark.asyncio
+    async def test_scan_excludes_disabled(self, store, indexer):
+        """Scan only includes enabled skills."""
+        await store.create(
+            name="disabled-skill",
+            content="Disabled.",
+            metadata=SkillMetadata(
+                name="disabled-skill",
+                description="A disabled skill",
+                category=SkillCategory.STYLE,
+                status=SkillStatus.DISABLED,
+            )
+        )
+        
+        entries = await indexer.scan()
+        assert not any(e.name == "disabled-skill" for e in entries)
+
+
+class TestSkillIndexerAvailable:
+    """Test progressive disclosure filtering."""
+    
+    @pytest.mark.asyncio
+    async def test_available_all(self, populated_store, indexer):
+        """Available() returns all enabled skills when no filters."""
+        await indexer.scan()
+        entries = await indexer.available()
+        assert len(entries) == 3
+    
+    @pytest.mark.asyncio
+    async def test_available_filter_by_category(self, populated_store, indexer):
+        """Available() filters by category."""
+        await indexer.scan()
+        entries = await indexer.available(category=SkillCategory.STYLE)
+        assert len(entries) == 1
+        assert entries[0].name == "style-cyberpunk"
+    
+    @pytest.mark.asyncio
+    async def test_available_filter_by_scenario(self, populated_store, indexer):
+        """Available() filters by scenario; None = universal (included)."""
+        await indexer.scan()
+        # workflow-short-ad has scenario="product-video" (matches)
+        # error-kling-faces has scenario=None (universal, included)
+        # style-cyberpunk has scenario="style-transfer" (excluded)
+        entries = await indexer.available(scenario="product-video")
+        assert len(entries) == 2
+        names = {e.name for e in entries}
+        assert "workflow-short-ad" in names
+        assert "error-kling-faces" in names
+    
+    @pytest.mark.asyncio
+    async def test_available_filter_by_agent(self, populated_store, indexer):
+        """Available() filters by agent; None = universal (included)."""
+        await indexer.scan()
+        # workflow-short-ad has agent="director" (matches)
+        # style-cyberpunk and error-kling-faces have agent=None (universal)
+        entries = await indexer.available(agent="director")
+        assert len(entries) == 3  # All skills are available to director
+        names = {e.name for e in entries}
+        assert "workflow-short-ad" in names
+    
+    @pytest.mark.asyncio
+    async def test_available_exclusive_agent_filter(self, store, indexer):
+        """Skills with a specific agent constraint are excluded when filtering for another agent."""
+        # Create a skill only for "editor" agent
+        await store.create(
+            name="editor-only",
+            content="Editor skill.",
+            metadata=SkillMetadata(
+                name="editor-only",
+                description="Editor-only skill",
+                category=SkillCategory.STYLE,
+                agent="editor",
+            )
+        )
+        # Create a universal skill
+        await store.create(
+            name="universal",
+            content="Universal skill.",
+            metadata=SkillMetadata(
+                name="universal",
+                description="Universal skill",
+                category=SkillCategory.STYLE,
+            )
+        )
+        
+        await indexer.scan()
+        entries = await indexer.available(agent="director")
+        names = {e.name for e in entries}
+        assert "universal" in names  # Universal skills included
+        assert "editor-only" not in names  # Editor-only skill excluded
+
+
+class TestSkillIndexerPromptFormat:
+    """Test system prompt injection formatting."""
+    
+    @pytest.mark.asyncio
+    async def test_format_for_prompt(self, populated_store, indexer):
+        """Format produces OpenCode-style skill index."""
+        await indexer.scan()
+        entries = await indexer.available()
+        formatted = indexer.format_for_prompt(entries)
+        
+        assert "## Available Skills" in formatted
+        assert "- style-cyberpunk:" in formatted
+        assert "- workflow-short-ad:" in formatted
+        assert "- error-kling-faces:" in formatted
+    
+    @pytest.mark.asyncio
+    async def test_format_empty(self, indexer):
+        """Format handles empty index gracefully."""
+        formatted = indexer.format_for_prompt([])
+        assert "(None available)" in formatted
+
+
+class TestSkillIndexerCaching:
+    """Test index caching and staleness."""
+    
+    @pytest.mark.asyncio
+    async def test_is_stale_initial(self, indexer):
+        """Index is stale before first scan."""
+        assert indexer.is_stale() is True
+    
+    @pytest.mark.asyncio
+    async def test_is_stale_after_scan(self, indexer):
+        """Index is fresh immediately after scan."""
+        await indexer.scan()
+        assert indexer.is_stale() is False
+    
+    @pytest.mark.asyncio
+    async def test_refresh_if_stale(self, populated_store, indexer):
+        """Refresh rescans when stale, returns cached when fresh."""
+        # First call triggers scan
+        entries = await indexer.refresh_if_stale()
+        assert len(entries) == 3
+        
+        # Second call returns cached
+        entries2 = await indexer.refresh_if_stale()
+        assert entries2 is entries  # Same object (cached)
+    
+    @pytest.mark.asyncio
+    async def test_get_skill_names(self, populated_store, indexer):
+        """Get skill names returns list of strings."""
+        names = await indexer.get_skill_names()
+        assert isinstance(names, list)
+        assert all(isinstance(n, str) for n in names)
+        assert len(names) == 3


### PR DESCRIPTION
## Issues

Closes #34 and #35

## Summary

Sprint 3 Day 2: Skill System infrastructure + MVP CLI entry point.

## Part 1: SkillStore + SkillIndexer (#34)

### New Files
- `cine_mate/skills/models.py` — Pydantic V2 models with auto-generation provenance
- `cine_mate/skills/skill_store.py` — SQLite + filesystem CRUD with YAML frontmatter validation
- `cine_mate/skills/skill_indexer.py` — Progressive disclosure index builder (OpenCode pattern)
- `cine_mate/skills/data/style-cyberpunk/SKILL.md` — Pre-installed style skill
- `cine_mate/skills/data/workflow-short-ad/SKILL.md` — Pre-installed workflow skill

### Architecture
- OpenCode progressive disclosure: system prompt receives only name+description index
- Full SKILL.md loaded on-demand via tool (for #36)
- Hermes auto-generation: skills track source_run_id, source_error for provenance (for #38)

### Tests: 29 unit tests

## Part 2: MVP CLI (#35)

### New Files
- `cine_mate/cli/__init__.py` — Package init
- `cine_mate/cli/__main__.py` — Module entry point
- `cine_mate/cli/main.py` — Click CLI with create, loop, status commands
- `cine_mate/cli/commands.py` — Command implementations with mock executor

### Commands
- `cinemate create "prompt"\* — One-shot video creation with keyword-based intent parser
- `cinemate loop\* — Interactive conversation mode
- `cinemate status\* — System status (DB runs, skills, data directory)
- Mock provider default: no API key required for MVP

### Intent Parser
- Single-scene: script_gen → text_to_image → image_to_video
- Ad pipeline: hook → demo → CTA → compose (branching DAG)
- Multi-scene: script → img1, img2 → vid1, vid2 → compose (parallel branches)

### Tests: 25 unit tests

## Test Results

```
tests/unit/skills/test_skill_store.py — 29 passed
tests/unit/cli/test_cli.py — 25 passed
```

## Acceptance Criteria

- [x] SkillStore supports CRUD
- [x] SkillIndexer correctly scans and caches
- [x] Pre-installed skills are discoverable
- [x] `cinemate create` command available
- [x] CLI supports natural language input
- [x] Mock mode enabled by default
- [x] Unit tests pass (54/54)