### PR TITLE
feat(skills): SkillLoader + DirectorAgent integration (#36)

### DIFF
--- a/cine_mate/agents/director_agent.py
+++ b/cine_mate/agents/director_agent.py
@@ -4,6 +4,7 @@ Task 2.3 Implementation
 
 P0 Fix: Dependency injection for model + mock_mode support (closes #4)
 Sprint 2: Real DashScope API call + API Key validation
+Sprint 3: Skill System integration (progressive disclosure via SkillLoader)
 """
 
 import os
@@ -78,6 +79,7 @@ class DirectorAgent(ReActAgent):
     - Mock mode for testing (no API key)
     - Real DashScope API call (default)
     - API Key validation at init time
+    - Skill System integration (progressive disclosure)
     """
 
     def __init__(
@@ -87,7 +89,9 @@ class DirectorAgent(ReActAgent):
         api_key: Optional[str] = None,
         engine_tools: Optional[EngineTools] = None,
         use_mock: bool = False,
-        model=None  # Dependency injection for model
+        model=None,  # Dependency injection for model
+        skill_indexer=None,   # SkillIndexer for system prompt injection
+        skill_loader=None,    # SkillLoader for on-demand content loading
     ):
         # 1. Setup Model (Priority: injected model > use_mock > default)
         if model is not None:
@@ -108,8 +112,27 @@ class DirectorAgent(ReActAgent):
                 api_key=resolved_api_key,
             )
 
-        # 2. Load System Prompt
+        # 2. Load System Prompt (with optional skill index injection)
         sys_prompt = load_system_prompt()
+        self._skill_loader = skill_loader  # Store for async inject_skills
+
+        if skill_indexer:
+            # Note: Skill index injection is done async via inject_skills()
+            # to avoid event loop conflicts when called from async context.
+            # If called synchronously, we try best-effort.
+            import asyncio
+            try:
+                loop = asyncio.get_running_loop()
+                # We're in async context — store for later injection
+                self._pending_skill_indexer = skill_indexer
+            except RuntimeError:
+                # No running loop — safe to run sync
+                try:
+                    index_entries = asyncio.run(skill_indexer.scan())
+                    skill_section = skill_indexer.format_for_prompt(index_entries)
+                    sys_prompt = f"{sys_prompt}\n\n{skill_section}"
+                except Exception as e:
+                    print(f"Warning: Could not load skill index. Error: {e}")
 
         # 3. Setup Toolkit
         toolkit = None
@@ -121,6 +144,11 @@ class DirectorAgent(ReActAgent):
             toolkit.register_tool_function(engine_tools.get_run_list)
             toolkit.register_tool_function(engine_tools.submit_plan)
 
+            # Register load_skill tool if skill_loader is provided
+            if skill_loader:
+                from cine_mate.agents.tools.skill_tool import make_load_skill_tool
+                toolkit.register_tool_function(make_load_skill_tool(skill_loader))
+
         # 4. Initialize ReActAgent
         super().__init__(
             name=name,
@@ -130,3 +158,23 @@ class DirectorAgent(ReActAgent):
             toolkit=toolkit,
             memory=InMemoryMemory(),
         )
+    
+    async def inject_skills(self):
+        """
+        Inject skill index into system prompt (async-safe).
+        
+        Call this after agent creation when skill_indexer was provided
+        but couldn't be injected during __init__ due to event loop conflicts.
+        """
+        indexer = getattr(self, '_pending_skill_indexer', None)
+        if indexer is None:
+            return
+        
+        try:
+            index_entries = await indexer.scan()
+            skill_section = indexer.format_for_prompt(index_entries)
+            # _sys_prompt is the internal storage (sys_prompt is read-only property)
+            self._sys_prompt = f"{self._sys_prompt}\n\n{skill_section}"
+            del self._pending_skill_indexer
+        except Exception as e:
+            print(f"Warning: Could not inject skills. Error: {e}")

--- a/cine_mate/agents/tools/skill_tool.py
+++ b/cine_mate/agents/tools/skill_tool.py
@@ -1,0 +1,70 @@
+"""
+CineMate Skill Tool for AgentScope Toolkit.
+
+Provides the load_skill() tool function that the DirectorAgent can call
+to retrieve full skill content on-demand (progressive disclosure pattern).
+
+Registration:
+    toolkit.register_tool_function(make_load_skill_tool(skill_loader))
+"""
+
+from typing import Optional
+
+from agentscope.tool import ToolResponse
+
+from cine_mate.skills.skill_loader import SkillLoader
+
+
+def make_load_skill_tool(loader: SkillLoader):
+    """
+    Create an async load_skill tool function bound to a SkillLoader instance.
+    
+    The returned function can be registered with AgentScope Toolkit:
+        toolkit.register_tool_function(make_load_skill_tool(loader))
+    
+    Args:
+        loader: SkillLoader instance backing the tool
+    
+    Returns:
+        Async function: load_skill(name: str) -> ToolResponse
+    """
+    
+    async def load_skill(name: str) -> ToolResponse:
+        """
+        Load the full content of a skill by name.
+        
+        Use this when you need detailed guidance on style, workflow,
+        or error recovery that isn't covered by the skill index alone.
+        
+        Args:
+            name: Skill identifier (e.g., "style-cyberpunk", "workflow-short-ad")
+        
+        Returns:
+            Full SKILL.md content wrapped in <skill_content> tags,
+            or an error message if the skill is not found.
+        """
+        content = await loader.load(name)
+        
+        if content is None:
+            available = await _list_available(loader)
+            return ToolResponse(content=[{
+                "type": "text",
+                "text": f"Skill '{name}' not found.\n\nAvailable skills:\n{available}"
+            }])
+        
+        return ToolResponse(content=[{"type": "text", "text": content}])
+    
+    # Attach docstring for AgentScope schema generation
+    load_skill.__name__ = "load_skill"
+    load_skill.__doc__ = """Load the full content of a skill by name. Use this when you need detailed guidance on style, workflow, or error recovery that isn't covered by the skill index alone. Args: name: Skill identifier (e.g., 'style-cyberpunk', 'workflow-short-ad'). Returns: Full SKILL.md content wrapped in <skill_content> tags, or an error message if the skill is not found."""
+    
+    return load_skill
+
+
+async def _list_available(loader: SkillLoader) -> str:
+    """List available skill names for error messages."""
+    skills = await loader.store.list_all()
+    if not skills:
+        return "(No skills installed)"
+    lines = [f"- {s.name}: {s.description}" for s in skills]
+    return "\n".join(lines)

--- a/cine_mate/skills/__init__.py
+++ b/cine_mate/skills/__init__.py
@@ -6,6 +6,7 @@ from cine_mate.skills.models import (
 )
 from cine_mate.skills.skill_store import SkillStore
 from cine_mate.skills.skill_indexer import SkillIndexer
+from cine_mate.skills.skill_loader import SkillLoader
 
 __all__ = [
     "SkillMetadata",
@@ -15,4 +16,5 @@ __all__ = [
     "SkillStatus",
     "SkillStore",
     "SkillIndexer",
+    "SkillLoader",
 ]

--- a/cine_mate/skills/skill_loader.py
+++ b/cine_mate/skills/skill_loader.py
@@ -1,0 +1,98 @@
+"""
+CineMate SkillLoader — On-demand full skill content retrieval.
+
+Wraps SkillStore to load complete SKILL.md content and return it in
+the OpenCode progressive disclosure format:
+    <skill_content name="...">
+    ... full SKILL.md body ...
+    </skill_content>
+
+This pattern prevents context window overflow — the system prompt only
+receives the skill index (name + description). Full content loads via
+the load_skill() tool when the DirectorAgent decides it's relevant.
+"""
+
+from pathlib import Path
+from typing import Optional
+
+from cine_mate.skills.skill_store import SkillStore
+from cine_mate.skills.models import SkillFullContent
+
+
+class SkillLoader:
+    """
+    Loads full skill content on-demand for the DirectorAgent.
+    
+    Usage pattern (progressive disclosure):
+    1. System prompt contains skill index (name + description only)
+    2. DirectorAgent calls load_skill(name) when it needs details
+    3. SkillLoader returns full SKILL.md wrapped in <skill_content> tags
+    
+    This follows the OpenCode pattern — compaction protects skill tool
+    calls from pruning, ensuring the loaded content stays in context.
+    """
+    
+    def __init__(self, store: SkillStore):
+        self.store = store
+    
+    async def load(self, name: str) -> Optional[str]:
+        """
+        Load a skill's full content, wrapped in <skill_content> tags.
+        
+        Args:
+            name: Skill identifier (e.g., "style-cyberpunk")
+        
+        Returns:
+            Formatted string: <skill_content name="...">...body...</skill_content>
+            or None if skill not found.
+        """
+        skill = await self.store.read(name)
+        if skill is None:
+            return None
+        
+        return self._format(skill)
+    
+    def _format(self, skill: SkillFullContent) -> str:
+        """Wrap skill content in OpenCode-style XML tags."""
+        meta = skill.metadata
+        header = (
+            f"<skill_content "
+            f'name="{meta.name}" '
+            f'category="{meta.category.value}" '
+            f'version="{meta.version}">'
+        )
+        footer = "</skill_content>"
+        
+        return f"{header}\n{skill.content}\n{footer}"
+    
+    async def load_with_metadata(self, name: str) -> Optional[dict]:
+        """
+        Load skill content with metadata as a structured dict.
+        
+        Useful for programmatic access (e.g., SkillReviewer analysis).
+        
+        Returns:
+            {
+                "name": str,
+                "description": str,
+                "category": str,
+                "tags": list,
+                "auto_generated": bool,
+                "content": str,
+            }
+            or None if not found.
+        """
+        skill = await self.store.read(name)
+        if skill is None:
+            return None
+        
+        meta = skill.metadata
+        return {
+            "name": meta.name,
+            "description": meta.description,
+            "category": meta.category.value,
+            "tags": meta.tags,
+            "auto_generated": meta.auto_generated,
+            "source_run_id": meta.source_run_id,
+            "content": skill.content,
+        }

--- a/tests/unit/skills/test_skill_loader.py
+++ b/tests/unit/skills/test_skill_loader.py
@@ -1,0 +1,313 @@
+"""
+Tests for CineMate SkillLoader and Agent integration.
+Covers on-demand loading, OpenCode format wrapping, and DirectorAgent skill injection.
+"""
+
+import pytest
+import tempfile
+from pathlib import Path
+
+from cine_mate.skills.skill_store import SkillStore
+from cine_mate.skills.skill_indexer import SkillIndexer
+from cine_mate.skills.skill_loader import SkillLoader
+from cine_mate.skills.models import SkillMetadata, SkillCategory
+from cine_mate.agents.tools.skill_tool import make_load_skill_tool
+
+
+# =============================================================================
+# Fixtures
+# =============================================================================
+
+@pytest.fixture
+async def skills_dir():
+    """Provide a temporary skills directory."""
+    with tempfile.TemporaryDirectory() as tmp:
+        yield Path(tmp)
+
+
+@pytest.fixture
+async def store(skills_dir):
+    """Provide a fresh SkillStore instance."""
+    s = SkillStore(skills_dir)
+    await s.init()
+    yield s
+
+
+@pytest.fixture
+async def populated_store(store):
+    """SkillStore with pre-installed test skills."""
+    await store.create(
+        name="style-cyberpunk",
+        content="""---
+name: style-cyberpunk
+description: Cyberpunk visual style with neon accents
+category: style
+version: 1.0.0
+---
+
+Cyberpunk style guide content with neon details.
+""",
+        metadata=SkillMetadata(
+            name="style-cyberpunk",
+            description="Cyberpunk visual style with neon accents",
+            category=SkillCategory.STYLE,
+            version="1.0.0",
+        )
+    )
+    
+    await store.create(
+        name="workflow-short-ad",
+        content="""---
+name: workflow-short-ad
+description: 15-second product ad template
+category: workflow
+version: 2.0.0
+---
+
+Workflow steps: hook -> demo -> CTA.
+""",
+        metadata=SkillMetadata(
+            name="workflow-short-ad",
+            description="15-second product ad template",
+            category=SkillCategory.WORKFLOW,
+            version="2.0.0",
+        )
+    )
+    
+    yield store
+
+
+@pytest.fixture
+def loader(populated_store):
+    """Provide a SkillLoader backed by the populated store."""
+    return SkillLoader(populated_store)
+
+
+# =============================================================================
+# SkillLoader Tests
+# =============================================================================
+
+class TestSkillLoaderLoad:
+    """Test on-demand skill content loading."""
+    
+    @pytest.mark.asyncio
+    async def test_load_returns_formatted_content(self, loader):
+        """Load returns skill content wrapped in <skill_content> tags."""
+        result = await loader.load("style-cyberpunk")
+        
+        assert result is not None
+        assert '<skill_content' in result
+        assert 'name="style-cyberpunk"' in result
+        assert 'category="style"' in result
+        assert 'version="1.0.0"' in result
+        assert "Cyberpunk style guide content with neon details." in result
+        assert "</skill_content>" in result
+    
+    @pytest.mark.asyncio
+    async def test_load_missing_skill_returns_none(self, loader):
+        """Load non-existent skill returns None."""
+        result = await loader.load("nonexistent-skill")
+        assert result is None
+    
+    @pytest.mark.asyncio
+    async def test_load_includes_metadata_in_tags(self, loader):
+        """Load includes name, category, version in XML attributes."""
+        result = await loader.load("workflow-short-ad")
+        
+        assert 'name="workflow-short-ad"' in result
+        assert 'category="workflow"' in result
+        assert 'version="2.0.0"' in result
+        assert "Workflow steps: hook -> demo -> CTA." in result
+    
+    @pytest.mark.asyncio
+    async def test_load_with_metadata_returns_dict(self, loader):
+        """load_with_metadata returns structured dict."""
+        result = await loader.load_with_metadata("style-cyberpunk")
+        
+        assert result is not None
+        assert result["name"] == "style-cyberpunk"
+        assert result["description"] == "Cyberpunk visual style with neon accents"
+        assert result["category"] == "style"
+        assert result["tags"] == []
+        assert result["auto_generated"] is False
+        assert "Cyberpunk style guide content with neon details." in result["content"]
+    
+    @pytest.mark.asyncio
+    async def test_load_with_metadata_missing_returns_none(self, loader):
+        """load_with_metadata returns None for missing skills."""
+        result = await loader.load_with_metadata("nonexistent")
+        assert result is None
+
+
+# =============================================================================
+# Skill Tool Tests
+# =============================================================================
+
+class TestSkillTool:
+    """Test the load_skill() tool function for AgentScope."""
+    
+    @pytest.mark.asyncio
+    async def test_tool_returns_content_for_valid_skill(self, populated_store):
+        """Tool returns formatted content for existing skill."""
+        loader = SkillLoader(populated_store)
+        tool_fn = make_load_skill_tool(loader)
+        
+        response = await tool_fn("style-cyberpunk")
+        
+        assert response is not None
+        text = response.content[0]["text"]
+        assert '<skill_content' in text
+        assert "Cyberpunk style guide content with neon details." in text
+    
+    @pytest.mark.asyncio
+    async def test_tool_returns_error_for_missing_skill(self, populated_store):
+        """Tool returns error message with available skills for missing skill."""
+        loader = SkillLoader(populated_store)
+        tool_fn = make_load_skill_tool(loader)
+        
+        response = await tool_fn("nonexistent-skill")
+        
+        text = response.content[0]["text"]
+        assert "not found" in text
+        assert "Available skills:" in text
+        assert "style-cyberpunk" in text
+        assert "workflow-short-ad" in text
+    
+    @pytest.mark.asyncio
+    async def test_tool_has_correct_name(self, populated_store):
+        """Tool function has correct name for AgentScope registration."""
+        loader = SkillLoader(populated_store)
+        tool_fn = make_load_skill_tool(loader)
+        
+        assert tool_fn.__name__ == "load_skill"
+    
+    @pytest.mark.asyncio
+    async def test_tool_has_docstring(self, populated_store):
+        """Tool function has docstring for schema generation."""
+        loader = SkillLoader(populated_store)
+        tool_fn = make_load_skill_tool(loader)
+        
+        assert tool_fn.__doc__ is not None
+        assert "skill" in tool_fn.__doc__.lower()
+
+
+# =============================================================================
+# DirectorAgent Skill Integration Tests
+# =============================================================================
+
+class TestDirectorAgentSkillIntegration:
+    """Test DirectorAgent skill system integration (mock mode)."""
+    
+    @pytest.mark.asyncio
+    async def test_agent_accepts_skill_params(self, populated_store):
+        """DirectorAgent accepts skill_indexer and skill_loader params."""
+        from cine_mate.agents.director_agent import DirectorAgent
+        from cine_mate.agents.tools.engine_tools import EngineTools
+        
+        store = SkillStore(Path(tempfile.mktemp(suffix=".db")))
+        await store.init()
+        
+        indexer = SkillIndexer(store)
+        loader = SkillLoader(store)
+        tools = EngineTools(store_path=tempfile.mktemp(suffix=".db"))
+        await tools.init_db()
+        
+        # Should not raise
+        agent = DirectorAgent(
+            name="Director",
+            use_mock=True,
+            engine_tools=tools,
+            skill_indexer=indexer,
+            skill_loader=loader,
+        )
+        
+        assert agent is not None
+        assert agent.name == "Director"
+    
+    @pytest.mark.asyncio
+    async def test_agent_system_prompt_includes_skill_index(self, populated_store):
+        """Agent system prompt includes skill index after inject_skills() call."""
+        from cine_mate.agents.director_agent import DirectorAgent
+        from cine_mate.agents.tools.engine_tools import EngineTools
+        
+        indexer = SkillIndexer(populated_store)
+        loader = SkillLoader(populated_store)
+        tools = EngineTools(store_path=tempfile.mktemp(suffix=".db"))
+        await tools.init_db()
+        
+        agent = DirectorAgent(
+            name="Director",
+            use_mock=True,
+            engine_tools=tools,
+            skill_indexer=indexer,
+            skill_loader=loader,
+        )
+        
+        # Inject skills async (required when called from async context)
+        await agent.inject_skills()
+        
+        # The sys_prompt should now contain the skill index
+        sys_prompt = agent.sys_prompt
+        assert "## Available Skills" in sys_prompt
+        assert "style-cyberpunk" in sys_prompt
+        assert "workflow-short-ad" in sys_prompt
+    
+    @pytest.mark.asyncio
+    async def test_agent_without_skills_works_normally(self, populated_store):
+        """Agent works without skill params (backward compatible)."""
+        from cine_mate.agents.director_agent import DirectorAgent
+        
+        # Should not raise — skills are optional
+        agent = DirectorAgent(
+            name="Director",
+            use_mock=True,
+        )
+        
+        assert agent is not None
+        assert agent.name == "Director"
+        # No skill section in prompt
+        assert "## Available Skills" not in agent.sys_prompt
+    
+    @pytest.mark.asyncio
+    async def test_agent_with_only_indexer(self, populated_store):
+        """Agent works with only skill_indexer (no loader)."""
+        from cine_mate.agents.director_agent import DirectorAgent
+        from cine_mate.agents.tools.engine_tools import EngineTools
+        
+        indexer = SkillIndexer(populated_store)
+        tools = EngineTools(store_path=tempfile.mktemp(suffix=".db"))
+        await tools.init_db()
+        
+        agent = DirectorAgent(
+            name="Director",
+            use_mock=True,
+            engine_tools=tools,
+            skill_indexer=indexer,
+        )
+        
+        # Inject skills async
+        await agent.inject_skills()
+        
+        assert agent is not None
+        assert "## Available Skills" in agent.sys_prompt
+    
+    @pytest.mark.asyncio
+    async def test_agent_with_only_loader(self, populated_store):
+        """Agent works with only skill_loader (no indexer)."""
+        from cine_mate.agents.director_agent import DirectorAgent
+        from cine_mate.agents.tools.engine_tools import EngineTools
+        
+        loader = SkillLoader(populated_store)
+        tools = EngineTools(store_path=tempfile.mktemp(suffix=".db"))
+        await tools.init_db()
+        
+        agent = DirectorAgent(
+            name="Director",
+            use_mock=True,
+            engine_tools=tools,
+            skill_loader=loader,
+        )
+        
+        assert agent is not None
+        # No skill index in prompt (indexer not provided)
+        assert "## Available Skills" not in agent.sys_prompt


### PR DESCRIPTION
## Issue

Closes #36

## Summary

Sprint 3 Day 3 (Part 2): SkillLoader + DirectorAgent skill system integration.

## Deliverables

### cine_mate/skills/skill_loader.py
On-demand full SKILL.md content retrieval:
- `load(name)\*: Returns content wrapped in OpenCode-style `<skill_content>` XML tags
- `load_with_metadata(name)\*: Returns structured dict for programmatic access
- Follows progressive disclosure pattern — system prompt gets index only, full content via tool

### cine_mate/agents/tools/skill_tool.py
`load_skill()\* tool function for AgentScope Toolkit:
- Bound to SkillLoader instance via `make_load_skill_tool()\*
- Returns error message with available skills list when skill not found
- Proper docstring for AgentScope schema generation

### cine_mate/agents/director_agent.py (updated)
- Added `skill_indexer\* and `skill_loader\* optional parameters
- Skill index injected into system prompt during init (sync context)
- `inject_skills()\* async method for event-loop-safe injection (async context)
- `load_skill()\* tool registered in Toolkit when skill_loader provided
- Backward compatible: skills are optional, existing code unchanged

### tests/unit/skills/test_skill_loader.py
14 unit tests:
- 5 SkillLoader tests (format, missing, metadata tags, dict, missing dict)
- 4 SkillTool tests (valid content, error message, name, docstring)
- 5 DirectorAgent integration tests (params, prompt index, no-skill, indexer-only, loader-only)

## Test Results

```
tests/unit/skills/test_skill_loader.py  — 14/14 PASS
tests/unit/skills/ (all)               — 43/43 PASS
tests/unit/cli/                        — 25/25 PASS
tests/integration/test_mvp_demo.py     — 8/8 PASS
```

## Architecture

```
DirectorAgent.__init__()
├── Load base system prompt (intent_v1.md)
├── Sync context: Inject skill index via SkillIndexer.scan()
├── Async context: Store pending, call inject_skills() later
└── Register load_skill() tool if SkillLoader provided

DirectorAgent.inject_skills()  [async]
└── Scan skills → Format index → Append to _sys_prompt

Agent Toolkit
├── engine_tools (create_video, get_run_status, etc.)
└── load_skill(name) → <skill_content name="...">...</skill_content>
```

## Acceptance Criteria

- [x] SkillLoader loads on-demand
- [x] Director Agent injects skill index
- [x] load_skill() tool available in Toolkit