### PR TITLE
feat(skills): SkillReviewer auto-generation from PipelineRun analysis (#38)

### DIFF
--- a/cine_mate/skills/__init__.py
+++ b/cine_mate/skills/__init__.py
@@ -7,6 +7,7 @@ from cine_mate.skills.models import (
 from cine_mate.skills.skill_store import SkillStore
 from cine_mate.skills.skill_indexer import SkillIndexer
 from cine_mate.skills.skill_loader import SkillLoader
+from cine_mate.skills.skill_reviewer import SkillReviewer
 
 __all__ = [
     "SkillMetadata",
@@ -17,4 +18,5 @@ __all__ = [
     "SkillStore",
     "SkillIndexer",
     "SkillLoader",
+    "SkillReviewer",
 ]

--- a/cine_mate/skills/skill_reviewer.py
+++ b/cine_mate/skills/skill_reviewer.py
@@ -1,0 +1,284 @@
+"""
+CineMate SkillReviewer — Auto-generation of skills from PipelineRun analysis.
+
+Implements the Hermes auto-generation mechanism:
+- Analyzes PipelineRun execution logs and outcomes
+- Identifies reusable patterns (successful workflows, error recovery)
+- Creates new skills with provenance tracking (source_run_id, source_error)
+- Triggered by Orchestrator on pipeline completion (success/failure/retry)
+
+This is the self-improving component of the Skill System — the agent
+learns from experience and persists that knowledge as skills.
+"""
+
+import json
+from pathlib import Path
+from typing import Optional, List, Dict, Any
+from datetime import datetime
+
+from cine_mate.skills.skill_store import SkillStore
+from cine_mate.skills.models import SkillMetadata, SkillCategory
+
+
+class SkillReviewer:
+    """
+    Analyzes PipelineRun outcomes and auto-generates skills.
+    
+    Triggers:
+    - PipelineRun completion (success)
+    - PipelineRun failure with identifiable error patterns
+    - PipelineRun with retries (error recovery patterns)
+    
+    Output:
+    - New skills created via SkillStore with provenance metadata
+    - Skills marked as auto_generated=True for auditability
+    """
+    
+    def __init__(self, store: SkillStore):
+        self.store = store
+    
+    async def review(self, run_data: Dict[str, Any]) -> Optional[SkillMetadata]:
+        """
+        Review a completed PipelineRun and potentially create a skill.
+        
+        Args:
+            run_data: PipelineRun execution data containing:
+                - run_id: str
+                - status: "completed" | "failed" | "retried"
+                - intent: str (original user prompt intent)
+                - nodes: list of node execution records
+                - error: optional error info (for failed runs)
+                - retry_count: int (number of retries)
+        
+        Returns:
+            SkillMetadata if a skill was created, None otherwise.
+        """
+        status = run_data.get("status", "")
+        nodes = run_data.get("nodes", [])
+        intent = run_data.get("intent", "")
+        run_id = run_data.get("run_id", "")
+        error = run_data.get("error")
+        retry_count = run_data.get("retry_count", 0)
+        
+        # Determine review outcome
+        if status == "completed":
+            return await self._review_success(run_id, intent, nodes)
+        elif status == "failed" and error:
+            return await self._review_failure(run_id, intent, nodes, error)
+        elif status == "retried" and retry_count > 0:
+            return await self._review_retry(run_id, intent, nodes, retry_count)
+        
+        return None
+    
+    async def _review_success(
+        self, run_id: str, intent: str, nodes: List[Dict]
+    ) -> Optional[SkillMetadata]:
+        """
+        Review a successful run — look for reusable workflow patterns.
+        
+        Creates a workflow skill if the run used a non-trivial node pattern
+        (3+ nodes) that could serve as a template.
+        """
+        if len(nodes) < 3:
+            return None  # Too simple to be a reusable pattern
+        
+        # Extract node type sequence
+        node_sequence = [n.get("type", "") for n in nodes if n.get("type")]
+        
+        # Skip if we already have a very similar workflow
+        existing_skills = await self.store.list_all()
+        for skill in existing_skills:
+            if skill.auto_generated and skill.source_run_id == run_id:
+                return None  # Already reviewed this run
+        
+        # Generate skill from successful workflow
+        skill_name = f"workflow-auto-{run_id}"
+        description = f"Auto-generated from successful run: {intent[:50]}..."
+        
+        # Build skill content from execution data
+        content = self._build_workflow_content(intent, nodes, node_sequence)
+        
+        metadata = await self.store.create(
+            name=skill_name,
+            content=content,
+            metadata=SkillMetadata(
+                name=skill_name,
+                description=description,
+                category=SkillCategory.WORKFLOW,
+                auto_generated=True,
+                source_run_id=run_id,
+                tags=["auto-generated", "workflow"],
+            )
+        )
+        
+        return metadata
+    
+    async def _review_failure(
+        self, run_id: str, intent: str, nodes: List[Dict], error: Dict
+    ) -> Optional[SkillMetadata]:
+        """
+        Review a failed run — look for identifiable error patterns
+        that could become error recovery skills.
+        """
+        error_msg = error.get("message", "")
+        error_type = error.get("type", "unknown")
+        
+        # Skip generic errors
+        generic_errors = ["timeout", "cancelled", "user_interrupt"]
+        if any(g in error_type.lower() for g in generic_errors):
+            return None
+        
+        # Identify the failing node
+        failing_node = None
+        for node in nodes:
+            if node.get("status") == "failed":
+                failing_node = node
+                break
+        
+        if not failing_node:
+            return None
+        
+        node_type = failing_node.get("type", "unknown")
+        
+        # Generate error recovery skill
+        skill_name = f"error-{node_type}-{error_type.lower().replace(' ', '-')[:20]}"
+        description = f"Recovery pattern for {node_type} error: {error_msg[:60]}..."
+        
+        content = self._build_error_content(node_type, error_msg, error_type, failing_node)
+        
+        metadata = await self.store.create(
+            name=skill_name,
+            content=content,
+            metadata=SkillMetadata(
+                name=skill_name,
+                description=description,
+                category=SkillCategory.ERROR_RECOVERY,
+                auto_generated=True,
+                source_run_id=run_id,
+                source_error=error_type,
+                tags=["auto-generated", "error-recovery", node_type],
+            )
+        )
+        
+        return metadata
+    
+    async def _review_retry(
+        self, run_id: str, intent: str, nodes: List[Dict], retry_count: int
+    ) -> Optional[SkillMetadata]:
+        """
+        Review a retried run — capture the recovery pattern that
+        eventually succeeded after retries.
+        """
+        if retry_count < 2:
+            return None  # Single retry is too common to patternize
+        
+        # Find the node that required retries
+        retried_nodes = [n for n in nodes if n.get("retry_count", 0) > 0]
+        if not retried_nodes:
+            return None
+        
+        node = retried_nodes[0]
+        node_type = node.get("type", "unknown")
+        
+        skill_name = f"recovery-{node_type}-retry-{retry_count}"
+        description = f"Retry recovery for {node_type} ({retry_count} retries)"
+        
+        content = self._build_recovery_content(node_type, retry_count, node)
+        
+        metadata = await self.store.create(
+            name=skill_name,
+            content=content,
+            metadata=SkillMetadata(
+                name=skill_name,
+                description=description,
+                category=SkillCategory.ERROR_RECOVERY,
+                auto_generated=True,
+                source_run_id=run_id,
+                source_error=f"retry_{retry_count}",
+                tags=["auto-generated", "retry-recovery", node_type],
+            )
+        )
+        
+        return metadata
+    
+    # --- Content Builders ---
+    
+    def _build_workflow_content(
+        self, intent: str, nodes: List[Dict], node_sequence: List[str]
+    ) -> str:
+        """Build workflow skill content from successful execution."""
+        lines = [
+            f"# Auto-Generated Workflow: {intent[:50]}",
+            "",
+            "## Node Sequence",
+            "",
+        ]
+        for i, node_type in enumerate(node_sequence):
+            lines.append(f"{i+1}. `{node_type}`")
+        
+        lines.extend([
+            "",
+            "## Configuration",
+            "",
+            "```json",
+            json.dumps({
+                "nodes": [
+                    {"id": n.get("id", ""), "type": n.get("type", ""), "params": n.get("params", {})}
+                    for n in nodes
+                ]
+            }, indent=2, ensure_ascii=False),
+            "```",
+            "",
+            "## Notes",
+            "",
+            f"- Auto-generated from run execution",
+            f"- Total nodes: {len(nodes)}",
+            f"- Original intent: {intent}",
+        ])
+        return "\n".join(lines)
+    
+    def _build_error_content(
+        self, node_type: str, error_msg: str, error_type: str, node: Dict
+    ) -> str:
+        """Build error recovery skill content."""
+        return f"""# Error Recovery: {node_type} — {error_type}
+
+## Error Pattern
+- **Node Type**: `{node_type}`
+- **Error Type**: {error_type}
+- **Message**: {error_msg}
+
+## Recommended Recovery
+1. Check input parameters for {node_type}
+2. Verify API key/credentials
+3. Retry with reduced parameters (lower resolution, shorter duration)
+4. If persistent, switch to fallback provider
+
+## Configuration at Failure
+```json
+{json.dumps(node.get("params", {}), indent=2, ensure_ascii=False)}
+```
+"""
+    
+    def _build_recovery_content(
+        self, node_type: str, retry_count: int, node: Dict
+    ) -> str:
+        """Build retry recovery skill content."""
+        return f"""# Retry Recovery: {node_type} ({retry_count} retries)
+
+## Pattern
+- **Node Type**: `{node_type}`
+- **Retries Before Success**: {retry_count}
+- **Node ID**: {node.get("id", "unknown")}
+
+## Recovery Steps
+1. First attempt failed — check error logs
+2. Retry with same parameters (transient error)
+3. If retry fails, reduce complexity (resolution/duration)
+4. If still failing, switch to fallback provider
+
+## Configuration
+```json
+{json.dumps(node.get("params", {}), indent=2, ensure_ascii=False)}
+```
+"""

--- a/tests/unit/skills/test_skill_reviewer.py
+++ b/tests/unit/skills/test_skill_reviewer.py
@@ -1,0 +1,370 @@
+"""
+Tests for CineMate SkillReviewer — auto-generation of skills from PipelineRun analysis.
+Covers success, failure, and retry review scenarios.
+"""
+
+import pytest
+import tempfile
+from pathlib import Path
+
+from cine_mate.skills.skill_store import SkillStore
+from cine_mate.skills.skill_reviewer import SkillReviewer
+from cine_mate.skills.models import SkillCategory
+
+
+# =============================================================================
+# Fixtures
+# =============================================================================
+
+@pytest.fixture
+async def skills_dir():
+    """Provide a temporary skills directory."""
+    with tempfile.TemporaryDirectory() as tmp:
+        yield Path(tmp)
+
+
+@pytest.fixture
+async def store(skills_dir):
+    """Provide a fresh SkillStore instance."""
+    s = SkillStore(skills_dir)
+    await s.init()
+    yield s
+
+
+@pytest.fixture
+def reviewer(store):
+    """Provide a SkillReviewer backed by the store."""
+    return SkillReviewer(store)
+
+
+# =============================================================================
+# Success Review Tests
+# =============================================================================
+
+class TestReviewSuccess:
+    """Test SkillReviewer on successful PipelineRun outcomes."""
+    
+    @pytest.mark.asyncio
+    async def test_creates_workflow_skill_for_complex_run(self, reviewer):
+        """Creates a workflow skill for runs with 3+ nodes."""
+        run_data = {
+            "run_id": "run_success_001",
+            "status": "completed",
+            "intent": "Create a cyberpunk product showcase video",
+            "nodes": [
+                {"id": "script", "type": "script_gen", "params": {"prompt": "test"}, "status": "succeeded"},
+                {"id": "image", "type": "text_to_image", "params": {"prompt": "test"}, "status": "succeeded"},
+                {"id": "video", "type": "image_to_video", "status": "succeeded"},
+            ],
+            "retry_count": 0,
+        }
+        
+        result = await reviewer.review(run_data)
+        
+        assert result is not None
+        assert result.auto_generated is True
+        assert result.source_run_id == "run_success_001"
+        assert result.category == SkillCategory.WORKFLOW
+        assert "workflow-auto-run_success_001" in result.name
+    
+    @pytest.mark.asyncio
+    async def test_skips_simple_runs(self, reviewer):
+        """Skips runs with fewer than 3 nodes (too simple to patternize)."""
+        run_data = {
+            "run_id": "run_simple",
+            "status": "completed",
+            "intent": "Make a video",
+            "nodes": [
+                {"id": "vid", "type": "text_to_video", "status": "succeeded"},
+            ],
+            "retry_count": 0,
+        }
+        
+        result = await reviewer.review(run_data)
+        assert result is None
+    
+    @pytest.mark.asyncio
+    async def test_skips_already_reviewed_runs(self, reviewer):
+        """Does not create duplicate skills for the same run_id."""
+        run_data = {
+            "run_id": "run_dup",
+            "status": "completed",
+            "intent": "Test video",
+            "nodes": [
+                {"id": "a", "type": "script_gen", "status": "succeeded"},
+                {"id": "b", "type": "text_to_image", "status": "succeeded"},
+                {"id": "c", "type": "image_to_video", "status": "succeeded"},
+            ],
+            "retry_count": 0,
+        }
+        
+        # First review creates skill
+        result1 = await reviewer.review(run_data)
+        assert result1 is not None
+        
+        # Second review skips
+        result2 = await reviewer.review(run_data)
+        assert result2 is None
+    
+    @pytest.mark.asyncio
+    async def test_skill_content_includes_workflow(self, reviewer):
+        """Generated skill content includes node sequence and configuration."""
+        run_data = {
+            "run_id": "run_content_test",
+            "status": "completed",
+            "intent": "Product ad for headphones",
+            "nodes": [
+                {"id": "hook", "type": "text_to_video", "params": {"duration": 3}, "status": "succeeded"},
+                {"id": "demo", "type": "image_to_video", "params": {"duration": 5}, "status": "succeeded"},
+                {"id": "compose", "type": "video_compose", "status": "succeeded"},
+            ],
+            "retry_count": 0,
+        }
+        
+        result = await reviewer.review(run_data)
+        assert result is not None
+        
+        # Verify content was written to file
+        skill = await reviewer.store.read(result.name)
+        assert skill is not None
+        assert "text_to_video" in skill.content
+        assert "image_to_video" in skill.content
+        assert "video_compose" in skill.content
+
+
+# =============================================================================
+# Failure Review Tests
+# =============================================================================
+
+class TestReviewFailure:
+    """Test SkillReviewer on failed PipelineRun outcomes."""
+    
+    @pytest.mark.asyncio
+    async def test_creates_error_skill_for_identifiable_error(self, reviewer):
+        """Creates an error recovery skill for identifiable error patterns."""
+        run_data = {
+            "run_id": "run_fail_001",
+            "status": "failed",
+            "intent": "Generate a portrait video",
+            "nodes": [
+                {"id": "image", "type": "text_to_image", "status": "succeeded"},
+                {"id": "video", "type": "image_to_video", "status": "failed",
+                 "params": {"duration": 10, "resolution": "4k"}},
+            ],
+            "error": {
+                "type": "face_distortion",
+                "message": "Kling API returned distorted face rendering",
+            },
+            "retry_count": 0,
+        }
+        
+        result = await reviewer.review(run_data)
+        
+        assert result is not None
+        assert result.auto_generated is True
+        assert result.source_run_id == "run_fail_001"
+        assert result.source_error == "face_distortion"
+        assert result.category == SkillCategory.ERROR_RECOVERY
+    
+    @pytest.mark.asyncio
+    async def test_skips_generic_errors(self, reviewer):
+        """Skips timeout/cancelled/user_interrupt errors (too generic)."""
+        generic_errors = ["timeout", "cancelled", "user_interrupt"]
+        
+        for error_type in generic_errors:
+            run_data = {
+                "run_id": f"run_{error_type}",
+                "status": "failed",
+                "intent": "Test",
+                "nodes": [
+                    {"id": "vid", "type": "text_to_video", "status": "failed"},
+                ],
+                "error": {
+                    "type": error_type,
+                    "message": f"Operation {error_type}",
+                },
+                "retry_count": 0,
+            }
+            
+            result = await reviewer.review(run_data)
+            assert result is None, f"Should skip generic error: {error_type}"
+    
+    @pytest.mark.asyncio
+    async def test_skips_failure_without_error_info(self, reviewer):
+        """Skips failures with no error details."""
+        run_data = {
+            "run_id": "run_no_error",
+            "status": "failed",
+            "intent": "Test",
+            "nodes": [],
+            "retry_count": 0,
+        }
+        
+        result = await reviewer.review(run_data)
+        assert result is None
+    
+    @pytest.mark.asyncio
+    async def test_error_skill_content_includes_recovery_steps(self, reviewer):
+        """Error skill content includes recovery recommendations."""
+        run_data = {
+            "run_id": "run_error_content",
+            "status": "failed",
+            "intent": "Generate video",
+            "nodes": [
+                {"id": "video", "type": "image_to_video", "status": "failed",
+                 "params": {"duration": 10}},
+            ],
+            "error": {
+                "type": "out_of_memory",
+                "message": "GPU memory exceeded for 4k resolution",
+            },
+            "retry_count": 0,
+        }
+        
+        result = await reviewer.review(run_data)
+        assert result is not None
+        
+        skill = await reviewer.store.read(result.name)
+        assert skill is not None
+        assert "Recovery" in skill.content or "recovery" in skill.content.lower()
+        assert "out_of_memory" in skill.content
+
+
+# =============================================================================
+# Retry Review Tests
+# =============================================================================
+
+class TestReviewRetry:
+    """Test SkillReviewer on retried PipelineRun outcomes."""
+    
+    @pytest.mark.asyncio
+    async def test_creates_recovery_skill_for_multiple_retries(self, reviewer):
+        """Creates a retry recovery skill for 2+ retries."""
+        run_data = {
+            "run_id": "run_retry_001",
+            "status": "retried",
+            "intent": "Generate a long video",
+            "nodes": [
+                {"id": "video", "type": "image_to_video", "status": "succeeded",
+                 "retry_count": 3, "params": {"duration": 30}},
+            ],
+            "retry_count": 3,
+        }
+        
+        result = await reviewer.review(run_data)
+        
+        assert result is not None
+        assert result.auto_generated is True
+        assert result.source_run_id == "run_retry_001"
+        assert result.source_error == "retry_3"
+        assert result.category == SkillCategory.ERROR_RECOVERY
+    
+    @pytest.mark.asyncio
+    async def test_skips_single_retry(self, reviewer):
+        """Skips runs with only 1 retry (too common to patternize)."""
+        run_data = {
+            "run_id": "run_single_retry",
+            "status": "retried",
+            "intent": "Test",
+            "nodes": [
+                {"id": "video", "type": "image_to_video", "status": "succeeded",
+                 "retry_count": 1},
+            ],
+            "retry_count": 1,
+        }
+        
+        result = await reviewer.review(run_data)
+        assert result is None
+    
+    @pytest.mark.asyncio
+    async def test_skips_retry_without_retried_nodes(self, reviewer):
+        """Skips when no nodes actually had retries."""
+        run_data = {
+            "run_id": "run_no_retried_nodes",
+            "status": "retried",
+            "intent": "Test",
+            "nodes": [
+                {"id": "video", "type": "image_to_video", "status": "succeeded",
+                 "retry_count": 0},
+            ],
+            "retry_count": 3,
+        }
+        
+        result = await reviewer.review(run_data)
+        assert result is None
+    
+    @pytest.mark.asyncio
+    async def test_recovery_skill_content_includes_retry_info(self, reviewer):
+        """Recovery skill content includes retry count and configuration."""
+        run_data = {
+            "run_id": "run_retry_content",
+            "status": "retried",
+            "intent": "Generate video",
+            "nodes": [
+                {"id": "video", "type": "text_to_video", "status": "succeeded",
+                 "retry_count": 4, "params": {"duration": 60, "resolution": "1080p"}},
+            ],
+            "retry_count": 4,
+        }
+        
+        result = await reviewer.review(run_data)
+        assert result is not None
+        
+        skill = await reviewer.store.read(result.name)
+        assert skill is not None
+        assert "4" in skill.content  # Retry count
+        assert "text_to_video" in skill.content
+
+
+# =============================================================================
+# Edge Cases
+# =============================================================================
+
+class TestReviewerEdgeCases:
+    """Test SkillReviewer edge cases."""
+    
+    @pytest.mark.asyncio
+    async def test_unknown_status_returns_none(self, reviewer):
+        """Unknown status returns None."""
+        run_data = {
+            "run_id": "run_unknown",
+            "status": "unknown_status",
+            "intent": "Test",
+            "nodes": [],
+            "retry_count": 0,
+        }
+        
+        result = await reviewer.review(run_data)
+        assert result is None
+    
+    @pytest.mark.asyncio
+    async def test_empty_nodes_handled_gracefully(self, reviewer):
+        """Empty nodes list handled without errors."""
+        run_data = {
+            "run_id": "run_empty",
+            "status": "completed",
+            "intent": "Test",
+            "nodes": [],
+            "retry_count": 0,
+        }
+        
+        result = await reviewer.review(run_data)
+        assert result is None  # Too few nodes
+    
+    @pytest.mark.asyncio
+    async def test_missing_run_id_handled_gracefully(self, reviewer):
+        """Missing run_id handled without errors."""
+        run_data = {
+            "status": "completed",
+            "intent": "Test",
+            "nodes": [
+                {"id": "a", "type": "script_gen", "status": "succeeded"},
+                {"id": "b", "type": "text_to_image", "status": "succeeded"},
+                {"id": "c", "type": "image_to_video", "status": "succeeded"},
+            ],
+            "retry_count": 0,
+        }
+        
+        # Should not raise, creates skill with empty run_id
+        result = await reviewer.review(run_data)
+        assert result is not None


### PR DESCRIPTION
## Issue

Closes #38

## Summary

Sprint 3 Day 4: SkillReviewer — auto-generation of skills from PipelineRun execution analysis.

## Deliverables

### cine_mate/skills/skill_reviewer.py
Analyzes PipelineRun outcomes and creates skills automatically:

| Outcome | Trigger | Skill Type |
|---------|---------|------------|
| Success (3+ nodes) | Reusable workflow pattern | WORKFLOW |
| Failure (identifiable error) | Face distortion, OOM, API errors | ERROR_RECOVERY |
| Retry (2+ retries) | Transient error recovery | ERROR_RECOVERY |

**Skips**:
- Simple runs (<3 nodes) — too trivial to patternize
- Generic errors (timeout/cancelled/user_interrupt) — no actionable pattern
- Already-reviewed runs (dedup by source_run_id)
- Single retries — too common to be a pattern

### Provenance Tracking
All auto-generated skills include:
- `auto_generated=True` — distinguishes from hand-written skills
- `source_run_id` — link to originating PipelineRun
- `source_error` — error pattern that triggered generation (for failures)

### tests/unit/skills/test_skill_reviewer.py
15 unit tests:
- 4 success review tests (workflow creation, skip simple, dedup, content)
- 4 failure review tests (error skill, skip generic, skip no-error, content)
- 4 retry review tests (recovery skill, skip single, skip no-retried, content)
- 3 edge case tests (unknown status, empty nodes, missing run_id)

## Test Results

```
tests/unit/skills/test_skill_reviewer.py — 15/15 PASS
```

## Architecture

This implements the **Hermes auto-generation mechanism** — the agent learns from experience and persists that knowledge as skills. The flow:

```
PipelineRun completes
    ↓
SkillReviewer.review(run_data)
    ↓
┌─────────────┬──────────────┬──────────────┐
│  Success    │  Failure     │  Retry (2+)  │
│  (3+ nodes) │  (identifi-  │  (retried    │
│             │   able err)  │   nodes)     │
└──────┬──────┴──────┬───────┴──────┬───────┘
       ↓             ↓              ↓
  WORKFLOW      ERROR_RECOVERY  ERROR_RECOVERY
  skill         skill           skill
```

## Acceptance Criteria

- [x] SkillReviewer identifies reusable experience patterns
- [x] Orchestrator integration point ready (trigger on completion)
- [x] Unit tests pass (15/15)