### PR TITLE
feat(cli): Video Git commands — history, diff, branches (#39)

### DIFF
--- a/cine_mate/cli/main.py
+++ b/cine_mate/cli/main.py
@@ -17,6 +17,11 @@ from cine_mate.cli.commands import (
     cmd_loop,
     cmd_status,
 )
+from cine_mate.cli.video_git import (
+    cmd_history,
+    cmd_diff,
+    cmd_branches,
+)
 
 
 @click.group(invoke_without_command=True)
@@ -99,6 +104,51 @@ def status(ctx):
         db_path=db_path,
         data_dir=data_dir,
     ))
+
+
+@cli.command("history")
+@click.option("--limit", default=20, help="Number of runs to show.")
+@click.option("--branch", default=None, help="Filter by branch name.")
+@click.option("--run", "run_id", default=None, help="Show details for a specific run.")
+@click.pass_context
+def history_cmd(ctx, limit: int, branch: Optional[str], run_id: Optional[str]):
+    """Show run history (Video Git log)."""
+    db_path = ctx.obj.get("db_path")
+
+    asyncio.run(cmd_history(
+        db_path=db_path,
+        limit=limit,
+        branch=branch,
+        run_id=run_id,
+    ))
+
+
+@cli.command()
+@click.argument("run_id", required=False)
+@click.option("--parent", "parent_run_id", default=None, help="Compare against this parent run.")
+@click.pass_context
+def diff(ctx, run_id: Optional[str], parent_run_id: Optional[str]):
+    """Show differences between two runs (Video Git diff).
+
+    Compares the given run_id with its parent (or use --parent to specify).
+    If no run_id, uses the most recent run.
+    """
+    db_path = ctx.obj.get("db_path")
+
+    asyncio.run(cmd_diff(
+        db_path=db_path,
+        run_id=run_id,
+        parent_run_id=parent_run_id,
+    ))
+
+
+@cli.command()
+@click.pass_context
+def branches(ctx):
+    """List all branches in the Video Git history."""
+    db_path = ctx.obj.get("db_path")
+
+    asyncio.run(cmd_branches(db_path=db_path))
 
 
 def main():

--- a/cine_mate/cli/video_git.py
+++ b/cine_mate/cli/video_git.py
@@ -1,0 +1,291 @@
+"""
+CineMate CLI — Video Git Commands
+Provides `cinemate history` and `cinemate diff` commands.
+"""
+
+import asyncio
+from pathlib import Path
+from typing import Optional
+
+import click
+
+from cine_mate.core.store import Store
+
+
+# ── Terminal formatting helpers ───────────────────────────────────────────
+
+# Status emoji map
+STATUS_EMOJI = {
+    "completed": "✅",
+    "failed": "❌",
+    "running": "🔄",
+    "pending": "⏳",
+    "paused": "⏸️",
+    "cancelled": "🚫",
+}
+
+
+def _color_status(status: str) -> str:
+    """Color-code status for terminal output."""
+    colors = {
+        "completed": "\033[92m",  # green
+        "failed": "\033[91m",     # red
+        "running": "\033[93m",    # yellow
+        "pending": "\033[90m",    # gray
+        "cancelled": "\033[90m",
+    }
+    reset = "\033[0m"
+    color = colors.get(status, "")
+    emoji = STATUS_EMOJI.get(status, "")
+    return f"{color}{emoji} {status}{reset}" if color else f"{emoji} {status}"
+
+
+def _format_table(header: list[str], rows: list[list[str]], col_widths: Optional[list[int]] = None):
+    """Print a simple terminal table."""
+    if not col_widths:
+        col_widths = [len(h) for h in header]
+        for row in rows:
+            for i, cell in enumerate(row):
+                if i < len(col_widths):
+                    col_widths[i] = max(col_widths[i], len(cell))
+
+    def fmt_row(cells):
+        return "  ".join(
+            cell.ljust(col_widths[i]) if i < len(col_widths) else cell
+            for i, cell in enumerate(cells)
+        )
+
+    click.echo(fmt_row(header))
+    click.echo("  ".join("-" * w for w in col_widths))
+    for row in rows:
+        click.echo(fmt_row(row))
+
+
+# ── History Command ───────────────────────────────────────────────────────
+
+async def cmd_history(
+    db_path: Optional[str] = None,
+    limit: int = 20,
+    branch: Optional[str] = None,
+    run_id: Optional[str] = None,
+):
+    """Show run history (Video Git log)."""
+
+    project_root = Path.cwd()
+    actual_db_path = Path(db_path) if db_path else project_root / "cinemate.db"
+
+    if not actual_db_path.exists():
+        click.echo("No database found. Run 'cinemate create' first.")
+        return
+
+    store = Store(actual_db_path)
+    await store.init_db()
+
+    if run_id:
+        # Show details for a specific run
+        run = await store.get_run(run_id)
+        if not run:
+            click.echo(f"Run '{run_id}' not found.")
+            return
+
+        click.echo(f"\n{'=' * 60}")
+        click.echo(f"Run Details: {run.run_id}")
+        click.echo(f"{'=' * 60}")
+        click.echo(f"  Commit:    {run.commit_msg or '(no message)'}")
+        click.echo(f"  Status:    {_color_status(run.status.value)}")
+        click.echo(f"  Branch:    {run.branch_name or 'main'}")
+        click.echo(f"  Parent:    {run.parent_run_id or '(root)'}")
+        click.echo(f"  Created:   {run.created_at.isoformat()}")
+        click.echo("")
+
+        # Node details
+        nodes = await store.list_node_executions_for_run(run_id)
+        if nodes:
+            click.echo("  Nodes:")
+            for node in nodes:
+                emoji = STATUS_EMOJI.get(node.status.value, "")
+                retry = f" (x{node.retry_count})" if node.retry_count > 0 else ""
+                error = f" — {node.error_msg}" if node.error_msg else ""
+                click.echo(f"    {emoji} {node.node_id:20s} {node.status.value}{retry}{error}")
+        else:
+            click.echo("  (no node executions recorded)")
+
+        click.echo(f"\n{'=' * 60}")
+    else:
+        # Show run history
+        runs = await store.list_runs(limit=limit, branch=branch)
+
+        click.echo(f"\n{'=' * 60}")
+        title = f"Run History"
+        if branch:
+            title += f" (branch: {branch})"
+        click.echo(f"{title}")
+        click.echo(f"{'=' * 60}")
+
+        if not runs:
+            click.echo("  No runs found.")
+            click.echo(f"{'=' * 60}")
+            return
+
+        # Table header
+        header = ["Status", "Run ID", "Commit", "Branch", "Created"]
+        rows = []
+        for run in runs:
+            status_str = _color_status(run.status.value)
+            commit = (run.commit_msg or "(no message)")[:35]
+            branch_name = run.branch_name or "main"
+            created = run.created_at.strftime("%Y-%m-%d %H:%M")
+            rows.append([status_str, run.run_id, commit, branch_name, created])
+
+        _format_table(header, rows, col_widths=[12, 22, 37, 10, 17])
+        click.echo(f"\n  Total: {len(runs)} runs shown")
+        click.echo(f"{'=' * 60}")
+
+
+# ── Diff Command ──────────────────────────────────────────────────────────
+
+async def cmd_diff(
+    db_path: Optional[str] = None,
+    run_id: Optional[str] = None,
+    parent_run_id: Optional[str] = None,
+):
+    """Show differences between two runs (Video Git diff)."""
+
+    project_root = Path.cwd()
+    actual_db_path = Path(db_path) if db_path else project_root / "cinemate.db"
+
+    if not actual_db_path.exists():
+        click.echo("No database found. Run 'cinemate create' first.")
+        return
+
+    store = Store(actual_db_path)
+    await store.init_db()
+
+    # Get the target run
+    if not run_id:
+        # Use the most recent run
+        runs = await store.list_runs(limit=1)
+        if not runs:
+            click.echo("No runs found.")
+            return
+        run_id = runs[0].run_id
+
+    target_run = await store.get_run(run_id)
+    if not target_run:
+        click.echo(f"Run '{run_id}' not found.")
+        return
+
+    # Determine comparison run
+    if parent_run_id:
+        base_run = await store.get_run(parent_run_id)
+    elif target_run.parent_run_id:
+        base_run = await store.get_run(target_run.parent_run_id)
+    else:
+        click.echo(f"Run '{run_id}' has no parent. Use --parent to specify a comparison run.")
+        return
+
+    if not base_run:
+        click.echo(f"Parent run '{target_run.parent_run_id}' not found.")
+        return
+
+    # Get node executions for both runs
+    target_nodes = await store.list_node_executions_for_run(run_id)
+    base_nodes = await store.list_node_executions_for_run(base_run.run_id)
+
+    target_map = {n.node_id: n for n in target_nodes}
+    base_map = {n.node_id: n for n in base_nodes}
+
+    # Compute diff
+    all_node_ids = sorted(set(target_map.keys()) | set(base_map.keys()))
+
+    click.echo(f"\n{'=' * 60}")
+    click.echo(f"Diff: {base_run.run_id} -> {target_run.run_id}")
+    click.echo(f"{'=' * 60}")
+    click.echo(f"  Base:  {base_run.commit_msg or '(no message)'}")
+    click.echo(f"  Target: {target_run.commit_msg or '(no message)'}")
+    click.echo("")
+
+    if not all_node_ids:
+        click.echo("  No nodes to compare.")
+        click.echo(f"{'=' * 60}")
+        return
+
+    # Table
+    header = ["Node", "Base Status", "Target Status", "Change"]
+    rows = []
+    for node_id in all_node_ids:
+        base_node = base_map.get(node_id)
+        target_node = target_map.get(node_id)
+
+        base_status = base_node.status.value if base_node else "(new)"
+        target_status = target_node.status.value if target_node else "(deleted)"
+
+        # Determine change type
+        if base_node and not target_node:
+            change = "🗑️  deleted"
+        elif not base_node and target_node:
+            change = "➕ added"
+        elif base_node.status != target_node.status:
+            change = "🔄 changed"
+        else:
+            change = "➖ same"
+
+        base_col = _color_status(base_status) if base_status != "(new)" else "\033[90m(new)\033[0m"
+        target_col = _color_status(target_status) if target_status != "(deleted)" else "\033[90m(deleted)\033[0m"
+
+        rows.append([node_id, base_col, target_col, change])
+
+    _format_table(header, rows, col_widths=[20, 15, 15, 15])
+
+    # Summary
+    added = sum(1 for r in rows if "added" in r[3])
+    deleted = sum(1 for r in rows if "deleted" in r[3])
+    changed = sum(1 for r in rows if "changed" in r[3])
+    same = sum(1 for r in rows if "same" in r[3])
+
+    click.echo(f"\n  Summary: {added} added, {deleted} deleted, {changed} changed, {same} same")
+    click.echo(f"{'=' * 60}")
+
+
+# ── Branches Command ──────────────────────────────────────────────────────
+
+async def cmd_branches(db_path: Optional[str] = None):
+    """List all branches in the Video Git history."""
+
+    project_root = Path.cwd()
+    actual_db_path = Path(db_path) if db_path else project_root / "cinemate.db"
+
+    if not actual_db_path.exists():
+        click.echo("No database found. Run 'cinemate create' first.")
+        return
+
+    store = Store(actual_db_path)
+    await store.init_db()
+
+    async with __import__("aiosqlite").connect(actual_db_path) as db:
+        db.row_factory = __import__("aiosqlite").Row
+        async with db.execute(
+            "SELECT branch_name, COUNT(*) as cnt, MAX(created_at) as latest "
+            "FROM pipeline_runs GROUP BY branch_name ORDER BY latest DESC"
+        ) as cursor:
+            rows = await cursor.fetchall()
+
+    click.echo(f"\n{'=' * 60}")
+    click.echo("Branches")
+    click.echo(f"{'=' * 60}")
+
+    if not rows:
+        click.echo("  No branches found.")
+        click.echo(f"{'=' * 60}")
+        return
+
+    header = ["Branch", "Runs", "Latest"]
+    table_rows = []
+    for row in rows:
+        branch = row["branch_name"] or "main"
+        latest = row["latest"]
+        table_rows.append([branch, str(row["cnt"]), latest])
+
+    _format_table(header, table_rows, col_widths=[15, 8, 20])
+    click.echo(f"\n  Total: {len(rows)} branches")
+    click.echo(f"{'=' * 60}")

--- a/cine_mate/core/store.py
+++ b/cine_mate/core/store.py
@@ -364,3 +364,67 @@ class Store:
                     ))
                 return results
 
+    # --- Video Git: List Operations ---
+
+    async def list_runs(self, limit: int = 50, branch: Optional[str] = None) -> list['PipelineRun']:
+        """List recent PipelineRuns, optionally filtered by branch."""
+        query = "SELECT * FROM pipeline_runs"
+        params: list = []
+        if branch:
+            query += " WHERE branch_name = ?"
+            params.append(branch)
+        query += " ORDER BY created_at DESC LIMIT ?"
+        params.append(limit)
+
+        async with aiosqlite.connect(self.db_path) as db:
+            db.row_factory = aiosqlite.Row
+            async with db.execute(query, params) as cursor:
+                rows = await cursor.fetchall()
+
+        from cine_mate.core.models import PipelineRun, RunStatus
+        results = []
+        for row in rows:
+            results.append(PipelineRun(
+                run_id=row["run_id"],
+                parent_run_id=row["parent_run_id"],
+                branch_name=row["branch_name"],
+                commit_msg=row["commit_msg"],
+                status=RunStatus(row["status"]),
+                dag_snapshot=json.loads(row["dag_snapshot"]) if row["dag_snapshot"] else None,
+                trace_id=row["trace_id"],
+                root_hash=row["root_hash"],
+                created_at=datetime.fromisoformat(row["created_at"]),
+            ))
+        return results
+
+    async def list_node_executions_for_run(self, run_id: str) -> list['NodeExecution']:
+        """List all node executions for a specific run."""
+        async with aiosqlite.connect(self.db_path) as db:
+            db.row_factory = aiosqlite.Row
+            async with db.execute(
+                "SELECT * FROM node_executions WHERE run_id = ? ORDER BY started_at",
+                (run_id,)
+            ) as cursor:
+                rows = await cursor.fetchall()
+
+        from cine_mate.core.models import NodeExecution, NodeStatus, NodeConfig
+        results = []
+        for row in rows:
+            config_data = json.loads(row["config_snapshot"]) if row["config_snapshot"] else None
+            config = NodeConfig(**config_data) if config_data else None
+            results.append(NodeExecution(
+                id=row["id"],
+                run_id=row["run_id"],
+                node_id=row["node_id"],
+                status=NodeStatus(row["status"]),
+                retry_count=row["retry_count"],
+                external_api_provider=row["external_api_provider"],
+                external_job_id=row["external_job_id"],
+                error_msg=row["error_msg"],
+                error_traceback=row["error_traceback"],
+                started_at=datetime.fromisoformat(row["started_at"]) if row["started_at"] else None,
+                completed_at=datetime.fromisoformat(row["completed_at"]) if row["completed_at"] else None,
+                config_snapshot=config,
+            ))
+        return results
+

--- a/tests/unit/cli/test_video_git.py
+++ b/tests/unit/cli/test_video_git.py
@@ -1,0 +1,355 @@
+"""
+Tests for CineMate CLI Video Git commands (history, diff, branches).
+Covers terminal output formatting, Store integration, and edge cases.
+"""
+
+import pytest
+import tempfile
+from pathlib import Path
+from click.testing import CliRunner
+
+from cine_mate.cli.main import cli
+from cine_mate.cli.video_git import (
+    cmd_history,
+    cmd_diff,
+    cmd_branches,
+    _color_status,
+    _format_table,
+)
+from cine_mate.core.store import Store
+from cine_mate.core.models import PipelineRun, RunStatus, NodeExecution, NodeStatus
+
+
+# =============================================================================
+# Fixtures
+# =============================================================================
+
+@pytest.fixture
+def runner():
+    """Provide a Click CLI test runner."""
+    return CliRunner()
+
+
+@pytest.fixture
+async def populated_store():
+    """Provide a Store with multiple runs and node executions."""
+    db_path = Path(tempfile.mktemp(suffix=".db"))
+    store = Store(db_path)
+    await store.init_db()
+
+    # Run 1: single scene (3 nodes)
+    run1 = PipelineRun(
+        run_id="run_001",
+        parent_run_id=None,
+        branch_name="main",
+        commit_msg="Cyberpunk city",
+        status=RunStatus.COMPLETED,
+    )
+    await store.create_run(run1)
+    for node_id in ["script", "image", "video"]:
+        await store.upsert_node_execution(NodeExecution(
+            id=f"exec_run_001_{node_id}",
+            run_id="run_001",
+            node_id=node_id,
+            status=NodeStatus.SUCCEEDED,
+        ))
+
+    # Run 2: ad pipeline (4 nodes), child of run_001
+    run2 = PipelineRun(
+        run_id="run_002",
+        parent_run_id="run_001",
+        branch_name="main",
+        commit_msg="Product ad",
+        status=RunStatus.COMPLETED,
+    )
+    await store.create_run(run2)
+    for node_id in ["hook", "demo", "cta", "compose"]:
+        await store.upsert_node_execution(NodeExecution(
+            id=f"exec_run_002_{node_id}",
+            run_id="run_002",
+            node_id=node_id,
+            status=NodeStatus.SUCCEEDED,
+        ))
+
+    # Run 3: failed run on a different branch
+    run3 = PipelineRun(
+        run_id="run_003",
+        parent_run_id=None,
+        branch_name="experiment",
+        commit_msg="Failed attempt",
+        status=RunStatus.FAILED,
+    )
+    await store.create_run(run3)
+    await store.upsert_node_execution(NodeExecution(
+        id="exec_run_003_video",
+        run_id="run_003",
+        node_id="video",
+        status=NodeStatus.FAILED,
+        error_msg="API timeout",
+    ))
+
+    yield store
+
+    if db_path.exists():
+        db_path.unlink()
+
+
+# =============================================================================
+# CLI Entry Tests
+# =============================================================================
+
+class TestVideoGitCliCommands:
+    """Test CLI command registration."""
+
+    def test_history_in_help(self, runner):
+        """History command appears in help."""
+        result = runner.invoke(cli, ["--help"])
+        assert result.exit_code == 0
+        assert "history" in result.output
+
+    def test_diff_in_help(self, runner):
+        """Diff command appears in help."""
+        result = runner.invoke(cli, ["--help"])
+        assert result.exit_code == 0
+        assert "diff" in result.output
+
+    def test_branches_in_help(self, runner):
+        """Branches command appears in help."""
+        result = runner.invoke(cli, ["--help"])
+        assert result.exit_code == 0
+        assert "branches" in result.output
+
+
+# =============================================================================
+# History Command Tests
+# =============================================================================
+
+class TestHistoryCommand:
+    """Test the `cinemate history` command."""
+
+    def test_history_shows_runs(self, runner, populated_store):
+        """History lists all runs."""
+        result = runner.invoke(cli, [
+            "--db-path", str(populated_store.db_path),
+            "history",
+        ])
+
+        assert result.exit_code == 0
+        assert "Run History" in result.output
+        assert "run_001" in result.output
+        assert "run_002" in result.output
+        assert "run_003" in result.output
+        assert "Cyberpunk city" in result.output
+        assert "Product ad" in result.output
+        assert "Failed attempt" in result.output
+
+    def test_history_filters_by_branch(self, runner, populated_store):
+        """History filters runs by branch."""
+        result = runner.invoke(cli, [
+            "--db-path", str(populated_store.db_path),
+            "history",
+            "--branch", "experiment",
+        ])
+
+        assert result.exit_code == 0
+        assert "run_003" in result.output
+        assert "run_001" not in result.output
+
+    def test_history_limits_results(self, runner, populated_store):
+        """History respects --limit flag."""
+        result = runner.invoke(cli, [
+            "--db-path", str(populated_store.db_path),
+            "history",
+            "--limit", "1",
+        ])
+
+        assert result.exit_code == 0
+        assert "Total: 1 runs shown" in result.output
+
+    def test_history_shows_run_details(self, runner, populated_store):
+        """History --run shows detailed node info."""
+        result = runner.invoke(cli, [
+            "--db-path", str(populated_store.db_path),
+            "history",
+            "--run", "run_001",
+        ])
+
+        assert result.exit_code == 0
+        assert "Run Details: run_001" in result.output
+        assert "Cyberpunk city" in result.output
+        assert "script" in result.output
+        assert "image" in result.output
+        assert "video" in result.output
+
+    def test_history_missing_run(self, runner, populated_store):
+        """History reports missing run."""
+        result = runner.invoke(cli, [
+            "--db-path", str(populated_store.db_path),
+            "history",
+            "--run", "nonexistent",
+        ])
+
+        assert result.exit_code == 0
+        assert "not found" in result.output
+
+    def test_history_no_database(self, runner):
+        """History reports missing database."""
+        result = runner.invoke(cli, [
+            "--db-path", "/tmp/nonexistent_cinemate.db",
+            "history",
+        ])
+
+        assert result.exit_code == 0
+        assert "No database found" in result.output
+
+
+# =============================================================================
+# Diff Command Tests
+# =============================================================================
+
+class TestDiffCommand:
+    """Test the `cinemate diff` command."""
+
+    def test_diff_shows_changes(self, runner, populated_store):
+        """Diff shows node-level changes between runs."""
+        result = runner.invoke(cli, [
+            "--db-path", str(populated_store.db_path),
+            "diff",
+            "run_002",
+            "--parent", "run_001",
+        ])
+
+        assert result.exit_code == 0
+        assert "Diff: run_001 -> run_002" in result.output
+        assert "Cyberpunk city" in result.output
+        assert "Product ad" in result.output
+        # run_002 has different nodes than run_001
+        assert "hook" in result.output
+        assert "script" in result.output
+
+    def test_diff_shows_summary(self, runner, populated_store):
+        """Diff includes change summary."""
+        result = runner.invoke(cli, [
+            "--db-path", str(populated_store.db_path),
+            "diff",
+            "run_002",
+            "--parent", "run_001",
+        ])
+
+        assert result.exit_code == 0
+        assert "Summary:" in result.output
+        assert "added" in result.output
+        assert "deleted" in result.output
+
+    def test_diff_no_parent_no_arg(self, runner, populated_store):
+        """Diff reports when run has no parent and no --parent given."""
+        # run_001 has no parent
+        result = runner.invoke(cli, [
+            "--db-path", str(populated_store.db_path),
+            "diff",
+            "run_001",
+        ])
+
+        assert result.exit_code == 0
+        assert "has no parent" in result.output
+
+    def test_diff_missing_run(self, runner, populated_store):
+        """Diff reports missing run."""
+        result = runner.invoke(cli, [
+            "--db-path", str(populated_store.db_path),
+            "diff",
+            "nonexistent",
+        ])
+
+        assert result.exit_code == 0
+        assert "not found" in result.output
+
+    def test_diff_no_database(self, runner):
+        """Diff reports missing database."""
+        result = runner.invoke(cli, [
+            "--db-path", "/tmp/nonexistent_cinemate.db",
+            "diff",
+        ])
+
+        assert result.exit_code == 0
+        assert "No database found" in result.output
+
+
+# =============================================================================
+# Branches Command Tests
+# =============================================================================
+
+class TestBranchesCommand:
+    """Test the `cinemate branches` command."""
+
+    def test_branches_shows_all_branches(self, runner, populated_store):
+        """Branches lists all branches."""
+        result = runner.invoke(cli, [
+            "--db-path", str(populated_store.db_path),
+            "branches",
+        ])
+
+        assert result.exit_code == 0
+        assert "Branches" in result.output
+        assert "main" in result.output
+        assert "experiment" in result.output
+
+    def test_branches_shows_run_counts(self, runner, populated_store):
+        """Branches shows correct run counts per branch."""
+        result = runner.invoke(cli, [
+            "--db-path", str(populated_store.db_path),
+            "branches",
+        ])
+
+        assert result.exit_code == 0
+        assert "Total: 2 branches" in result.output
+
+    def test_branches_no_database(self, runner):
+        """Branches reports missing database."""
+        result = runner.invoke(cli, [
+            "--db-path", "/tmp/nonexistent_cinemate.db",
+            "branches",
+        ])
+
+        assert result.exit_code == 0
+        assert "No database found" in result.output
+
+
+# =============================================================================
+# Formatting Helper Tests
+# =============================================================================
+
+class TestFormattingHelpers:
+    """Test terminal formatting helpers."""
+
+    def test_color_status_completed(self):
+        """Completed status has green color and checkmark."""
+        result = _color_status("completed")
+        assert "completed" in result
+        assert "\033[92m" in result  # green
+
+    def test_color_status_failed(self):
+        """Failed status has red color."""
+        result = _color_status("failed")
+        assert "failed" in result
+        assert "\033[91m" in result  # red
+
+    def test_color_status_unknown(self):
+        """Unknown status returns plain text."""
+        result = _color_status("unknown_status")
+        assert "unknown_status" in result
+
+    def test_format_table_outputs_header(self):
+        """Format table includes header row."""
+        import io
+        from contextlib import redirect_stdout
+
+        f = io.StringIO()
+        with redirect_stdout(f):
+            _format_table(["A", "B"], [["1", "2"]], col_widths=[5, 5])
+        output = f.getvalue()
+
+        assert "A" in output
+        assert "B" in output
+        assert "1" in output
+        assert "2" in output


### PR DESCRIPTION
## Issue

Closes #39

## Summary

Sprint 3 Day 4 (Part 2): Video Git CLI commands for run history and version comparison.

## Deliverables

### cine_mate/cli/video_git.py
Three new CLI commands:

| Command | Description |
|---------|-------------|
| `cinemate history\* | List runs with status, commit, branch, timestamp |
| `cinemate diff <id>\* | Compare nodes between two runs |
| `cinemate branches\* | List all branches with run counts |

**history options**:
- `--limit N\*: Control number of results (default: 20)
- `--branch NAME\*: Filter by branch name
- `--run ID\*: Show detailed node-level info for a specific run

**diff options**:
- Auto-detects parent run, or use `--parent ID\* to specify
- Shows added/deleted/changed/same nodes with summary

### cine_mate/core/store.py (updated)
Two new query methods:
- `list_runs(limit, branch)\*: List recent PipelineRuns
- `list_node_executions_for_run(run_id)\*: List all nodes for a run

### cine_mate/cli/main.py (updated)
Registered 3 new CLI commands: history, diff, branches.

### tests/unit/cli/test_video_git.py
21 unit tests:
- 3 CLI registration tests (help output)
- 6 history tests (list, filter, limit, details, missing, no-db)
- 5 diff tests (changes, summary, no-parent, missing, no-db)
- 3 branches tests (list, counts, no-db)
- 4 formatting helper tests (color status, table output)

## Terminal Output

### History
```
Run History
Status        Run ID     Commit            Branch   Created
------------  ---------  ----------------  -------  -----------------
✅ completed  run_003    多个场景的视频         main     2026-04-21 13:14
✅ completed  run_002    产品广告耳机          main     2026-04-21 13:14
✅ completed  run_001    赛博朋克城市夜景        main     2026-04-21 13:14
```

### Diff
```
Diff: run_001 -> run_002
Node                  Base Status    Target Status    Change
--------------------  -------------  ---------------  ---------------
node_compose          (new)          succeeded        ➕ added
node_image            succeeded      (deleted)        🗑️  deleted
node_script           succeeded      succeeded        ➖ same

Summary: 1 added, 1 deleted, 0 changed, 1 same
```

## Test Results

```
tests/unit/cli/test_video_git.py — 21/21 PASS
```

## Acceptance Criteria

- [x] `cinemate history` available
- [x] `cinemate diff` available
- [x] Output formatting complete with color and emoji